### PR TITLE
#10 - Add GPT as partition table when disk size are bigger than 2 TB

### DIFF
--- a/bin/appliance_console
+++ b/bin/appliance_console
@@ -173,7 +173,7 @@ To modify the configuration, use a web browser to access the management page.
           new_mask = ask_for_ipv4("Netmask", mask)
           new_gw   = ask_for_ipv4("Gateway", gw)
           new_dns1 = ask_for_ipv4("Primary DNS", dns1)
-          new_dns2 = ask_for_ipv4_or_none("Secondary DNS (Enter 'none' for no value)")
+          new_dns2 = ask_for_ipv4_or_none("Secondary DNS (Enter 'none' for no value)", dns2)
 
           new_search_order = ask_for_many("domain", "Domain search order", order)
 
@@ -225,7 +225,7 @@ Static Network Configuration
           new_prefix = ask_for_integer('IPv6 prefix length', 1..127, eth0.prefix6 || 64)
           new_gw = ask_for_ipv6('Default gateway', eth0.gateway6)
           new_dns1 = ask_for_ip('Primary DNS', dns1)
-          new_dns2 = ask_for_ipv6_or_none("Secondary DNS (Enter 'none' for no value)")
+          new_dns2 = ask_for_ipv6_or_none("Secondary DNS (Enter 'none' for no value)", dns2)
 
           new_search_order = ask_for_many('domain', 'Domain search order', order)
 

--- a/lib/manageiq-appliance_console.rb
+++ b/lib/manageiq-appliance_console.rb
@@ -24,6 +24,7 @@ require 'manageiq/appliance_console/logger'
 require 'manageiq/appliance_console/logging'
 
 require 'manageiq-gems-pending'
+require 'highline'
 
 require 'manageiq/appliance_console/certificate'
 require 'manageiq/appliance_console/certificate_authority'

--- a/lib/manageiq/appliance_console/database_replication.rb
+++ b/lib/manageiq/appliance_console/database_replication.rb
@@ -71,7 +71,7 @@ Replication Server Configuration
         primary_region_number =
           pg_conn.exec("SELECT last_value FROM miq_databases_id_seq").first["last_value"].to_i / 1_000_000_000_000
         self.cluster_name = "miq_region_#{primary_region_number}_cluster"
-      rescue PG::ConnectionBad => e
+      rescue PG::ConnectionBad, PG::UndefinedTable => e
         say("Failed to get primary region number #{e.message}")
         logger.error("Failed to get primary region number #{e.message}")
         return false

--- a/lib/manageiq/appliance_console/internal_database_configuration.rb
+++ b/lib/manageiq/appliance_console/internal_database_configuration.rb
@@ -65,11 +65,11 @@ module ApplianceConsole
     end
 
     def choose_disk
-      @disk = ask_for_disk("database disk")
+      @disk = ask_for_disk("database disk", false, true)
     end
 
     def check_disk_is_mount_point
-      error_message = "The disk for database must be a mount point"
+      error_message = "Internal databases require a volume mounted at #{mount_point}. Please add an unpartitioned disk and try again."
       raise error_message unless disk || pg_mount_point?
     end
 

--- a/lib/manageiq/appliance_console/prompts.rb
+++ b/lib/manageiq/appliance_console/prompts.rb
@@ -144,12 +144,12 @@ module ApplianceConsole
       just_ask(prompt, default, INT_REGEXP, "an integer", Integer) { |q| q.in = range if range }
     end
 
-    def ask_for_disk(disk_name, verify = true)
+    def ask_for_disk(disk_name, verify = true, silent = false)
       require "linux_admin"
       disks = LinuxAdmin::Disk.local.select { |d| d.partitions.empty? }
 
       if disks.empty?
-        say "No partition found for #{disk_name}. You probably want to add an unpartitioned disk and try again."
+        say("No partition found for #{disk_name}. You probably want to add an unpartitioned disk and try again.") unless silent
       else
         default_choice = disks.size == 1 ? "1" : nil
         disk = ask_with_menu(
@@ -160,9 +160,8 @@ module ApplianceConsole
           q.choice("Don't partition the disk") { nil }
         end
       end
-
       if verify && disk.nil?
-        say ""
+        say("")
         raise MiqSignalError unless are_you_sure?(" you don't want to partition the #{disk_name}")
       end
       disk

--- a/spec/internal_database_configuration_spec.rb
+++ b/spec/internal_database_configuration_spec.rb
@@ -35,19 +35,22 @@ describe ManageIQ::ApplianceConsole::InternalDatabaseConfiguration do
   context "#check_disk_is_mount_point" do
     it "not raise error if disk is given" do
       expect(@config).to receive(:disk).and_return("/x")
+      expect(@config).to receive(:mount_point).and_return("/x")
       @config.check_disk_is_mount_point
     end
 
     it "not raise error if no disk given but mount point for database is really a mount point" do
       expect(@config).to receive(:disk).and_return(nil)
+      expect(@config).to receive(:mount_point).and_return("/x")
       expect(@config).to receive(:pg_mount_point?).and_return(true)
       @config.check_disk_is_mount_point
     end
 
     it "raise error if no disk given and not a mount point" do
       expect(@config).to receive(:disk).and_return(nil)
+      expect(@config).to receive(:mount_point).and_return("/x")
       expect(@config).to receive(:pg_mount_point?).and_return(false)
-      expect { @config.check_disk_is_mount_point }.to raise_error(RuntimeError, "The disk for database must be a mount point")
+      expect { @config.check_disk_is_mount_point }.to raise_error(RuntimeError, /Internal databases require a volume mounted at \/x/)
     end
   end
 

--- a/spec/logical_volume_management_spec.rb
+++ b/spec/logical_volume_management_spec.rb
@@ -29,7 +29,8 @@ describe ManageIQ::ApplianceConsole::LogicalVolumeManagement do
 
   describe "#setup" do
     before do
-      expect(@disk_double).to receive(:create_partition_table)
+      expect(@disk_double).to receive(:create_partition_table).with("gpt")
+      expect(@disk_double).to receive(:create_partition_table).with("msdos")
       expect(@disk_double).to receive(:partitions).and_return([:fake_partition])
       @config.disk = @disk_double
 


### PR DESCRIPTION
### Implemented Solution
Integrated with LinuxAdmin library, passing from **logical_volume_management.rb** as parameter the partition_type to **create_partition_table** function.

### Solves Issue: #10