### PR TITLE
Keep previous second dns settings when reconfig network

### DIFF
--- a/bin/appliance_console
+++ b/bin/appliance_console
@@ -173,7 +173,7 @@ To modify the configuration, use a web browser to access the management page.
           new_mask = ask_for_ipv4("Netmask", mask)
           new_gw   = ask_for_ipv4("Gateway", gw)
           new_dns1 = ask_for_ipv4("Primary DNS", dns1)
-          new_dns2 = ask_for_ipv4_or_none("Secondary DNS (Enter 'none' for no value)")
+          new_dns2 = ask_for_ipv4_or_none("Secondary DNS (Enter 'none' for no value)", dns2)
 
           new_search_order = ask_for_many("domain", "Domain search order", order)
 
@@ -225,7 +225,7 @@ Static Network Configuration
           new_prefix = ask_for_integer('IPv6 prefix length', 1..127, eth0.prefix6 || 64)
           new_gw = ask_for_ipv6('Default gateway', eth0.gateway6)
           new_dns1 = ask_for_ip('Primary DNS', dns1)
-          new_dns2 = ask_for_ipv6_or_none("Secondary DNS (Enter 'none' for no value)")
+          new_dns2 = ask_for_ipv6_or_none("Secondary DNS (Enter 'none' for no value)", dns2)
 
           new_search_order = ask_for_many('domain', 'Domain search order', order)
 


### PR DESCRIPTION
ISSUE: appliance_console doesn't keep previous second dns settings when reconfigure network, which should be kept as default value for new second dns.
BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1439348

\cc @yrudman @gtanzillo 