### PR TITLE
require highline to get tests passing

### DIFF
--- a/lib/manageiq-appliance_console.rb
+++ b/lib/manageiq-appliance_console.rb
@@ -24,6 +24,7 @@ require 'manageiq/appliance_console/logger'
 require 'manageiq/appliance_console/logging'
 
 require 'manageiq-gems-pending'
+require 'highline'
 
 require 'manageiq/appliance_console/certificate'
 require 'manageiq/appliance_console/certificate_authority'


### PR DESCRIPTION
It's already required in `bin/appliance_console`, but I don't like the idea of adding the require to the spec file.