### PR TITLE
[WIP] use GPT partition table to support partition > 2TB

### DIFF
--- a/lib/manageiq/appliance_console/logical_volume_management.rb
+++ b/lib/manageiq/appliance_console/logical_volume_management.rb
@@ -41,7 +41,7 @@ module ApplianceConsole
     private
 
     def create_partition_to_fill_disk
-      disk.create_partition_table
+      disk.create_partition_table("GPT")
       AwesomeSpawn.run!("parted -s #{disk.path} mkpart primary 0% 100%")
 
       self.disk = LinuxAdmin::Disk.local.find { |d| d.path == disk.path }

--- a/lib/manageiq/appliance_console/temp_storage_configuration.rb
+++ b/lib/manageiq/appliance_console/temp_storage_configuration.rb
@@ -67,7 +67,7 @@ module ApplianceConsole
     # FIXME: Copied from InternalDatabaseConfiguration - remove both when LinuxAdmin updated
     def create_partition_to_fill_disk(disk)
       # @disk.create_partition('primary', '100%')
-      disk.create_partition_table # LinuxAdmin::Disk.create_partition has this already...
+      disk.create_partition_table("GPT") # LinuxAdmin::Disk.create_partition has this already...
       AwesomeSpawn.run!("parted -s #{disk.path} mkpart primary 0% 100%")
 
       # FIXME: Refetch the disk after creating the partition


### PR DESCRIPTION
ISSUE:
Can't create partition > 2 TB becuase using MBR partition table doesn't support, and that lead to initialize postgresql database failed. Use GPT partition table to fix that.
BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1506997

\cc @gtanzillo @yrudman @bdunne 
@miq-bot add-label wip, bug

@gtanzillo This should work but we'd better find a more than 2TB hard disk to test that before merge