### PR TITLE
correct error message for create internal database without unpartitioned disk available

### DIFF
--- a/lib/manageiq/appliance_console/internal_database_configuration.rb
+++ b/lib/manageiq/appliance_console/internal_database_configuration.rb
@@ -65,11 +65,11 @@ module ApplianceConsole
     end
 
     def choose_disk
-      @disk = ask_for_disk("database disk")
+      @disk = ask_for_disk("database disk", false, true)
     end
 
     def check_disk_is_mount_point
-      error_message = "The disk for database must be a mount point"
+      error_message = "Internal databases require a volume mounted at #{mount_point}. Please add an unpartitioned disk and try again."
       raise error_message unless disk || pg_mount_point?
     end
 

--- a/lib/manageiq/appliance_console/prompts.rb
+++ b/lib/manageiq/appliance_console/prompts.rb
@@ -144,12 +144,12 @@ module ApplianceConsole
       just_ask(prompt, default, INT_REGEXP, "an integer", Integer) { |q| q.in = range if range }
     end
 
-    def ask_for_disk(disk_name, verify = true)
+    def ask_for_disk(disk_name, verify = true, silent = false)
       require "linux_admin"
       disks = LinuxAdmin::Disk.local.select { |d| d.partitions.empty? }
 
       if disks.empty?
-        say "No partition found for #{disk_name}. You probably want to add an unpartitioned disk and try again."
+        say("No partition found for #{disk_name}. You probably want to add an unpartitioned disk and try again.") unless silent
       else
         default_choice = disks.size == 1 ? "1" : nil
         disk = ask_with_menu(
@@ -160,9 +160,8 @@ module ApplianceConsole
           q.choice("Don't partition the disk") { nil }
         end
       end
-
       if verify && disk.nil?
-        say ""
+        say("")
         raise MiqSignalError unless are_you_sure?(" you don't want to partition the #{disk_name}")
       end
       disk

--- a/spec/internal_database_configuration_spec.rb
+++ b/spec/internal_database_configuration_spec.rb
@@ -35,19 +35,22 @@ describe ManageIQ::ApplianceConsole::InternalDatabaseConfiguration do
   context "#check_disk_is_mount_point" do
     it "not raise error if disk is given" do
       expect(@config).to receive(:disk).and_return("/x")
+      expect(@config).to receive(:mount_point).and_return("/x")
       @config.check_disk_is_mount_point
     end
 
     it "not raise error if no disk given but mount point for database is really a mount point" do
       expect(@config).to receive(:disk).and_return(nil)
+      expect(@config).to receive(:mount_point).and_return("/x")
       expect(@config).to receive(:pg_mount_point?).and_return(true)
       @config.check_disk_is_mount_point
     end
 
     it "raise error if no disk given and not a mount point" do
       expect(@config).to receive(:disk).and_return(nil)
+      expect(@config).to receive(:mount_point).and_return("/x")
       expect(@config).to receive(:pg_mount_point?).and_return(false)
-      expect { @config.check_disk_is_mount_point }.to raise_error(RuntimeError, "The disk for database must be a mount point")
+      expect { @config.check_disk_is_mount_point }.to raise_error(RuntimeError, /Internal databases require a volume mounted at \/x/)
     end
   end
 


### PR DESCRIPTION
Issue:
Now create internal database without unpartitioned disk, applaince console will ask are you sure for that, and whether choose yes or no will lead to configure fail. So we just show configure fail because of no unpartitioned disk and mount point is not a disk, and don't ask this not useful "are you sure"
BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1508958

\cc @yrudman @gtanzillo 
@miq-bot  add-label wip, bug