### PR TITLE
Hint for reset database error

### DIFF
--- a/lib/manageiq/appliance_console/database_configuration.rb
+++ b/lib/manageiq/appliance_console/database_configuration.rb
@@ -80,7 +80,8 @@ module ApplianceConsole
     end
 
     def create_region
-      ManageIQ::ApplianceConsole::Utilities.bail_if_db_connections("preventing the setup of a database region")
+      hint = "Please stop the EVM server process on all appliances in the region"
+      ManageIQ::ApplianceConsole::Utilities.bail_if_db_connections("preventing the setup of a database region.\n#{hint}")
       log_and_feedback(__method__) do
         ManageIQ::ApplianceConsole::Utilities.rake("evm:db:region", ["--", {:region => region}])
       end


### PR DESCRIPTION
Issue:
When reset database with connected appliances, it shows `There are xx existing connections to the database preventing the setup of a database region`, should give a hint suggest user close those evm servers.

BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1512840

\cc @yrudman @gtanzillo 
@miq-bot add-label wip, bug