### PR TITLE
fix appliance console cli dump exception stacks if -k when key exist

### DIFF
--- a/lib/manageiq/appliance_console/cli.rb
+++ b/lib/manageiq/appliance_console/cli.rb
@@ -254,7 +254,8 @@ module ApplianceConsole
     def create_key
       say "#{key_configuration.action} encryption key"
       unless key_configuration.activate
-        raise "Could not create encryption key (v2_key)"
+        say("Could not create encryption key (v2_key)")
+        exit(1)
       end
     end
 


### PR DESCRIPTION
Issue:
If run `appliance_console_cli -k` when v2 key exists, it will display error message and dump ruby exception stacks. It should only display error message.
BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1506045

\cc @yrudman @gtanzillo 
@miq-bot add-label bug