### PR TITLE
cli with --standalone option should work without --internal and --region

### DIFF
--- a/lib/manageiq/appliance_console/cli.rb
+++ b/lib/manageiq/appliance_console/cli.rb
@@ -36,11 +36,11 @@ module ApplianceConsole
     end
 
     def database?
-      hostname
+      options[:standalone] || hostname
     end
 
     def local_database?
-      database? && local?(hostname)
+      database? && (local?(hostname) || options[:standalone])
     end
 
     def certs?
@@ -134,8 +134,12 @@ module ApplianceConsole
         opt :extauth_opts,         "External Authentication Options",   :type => :string
         opt :server,               "Server status",                     :type => :string
       end
-      Trollop.die :region, "needed when setting up a local database" if options[:region].nil? && local_database?
+      Trollop.die :region, "needed when setting up a local database" if region_number_required? && options[:region].nil?
       self
+    end
+
+    def region_number_required?
+      !options[:standalone] && local_database?
     end
 
     def run


### PR DESCRIPTION
Issue: 
In appliance_console_cli, when given options `--standalone`, it should configure database without `--internal` and without `--region`. For example this should be correct:
```bash
appliance_console_cli --username root --password smartvm --dbname vmdb_production --standalone --key --dbdisk /dev/vdb
```
BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1513584

\cc @yrudman @carbonin  @gtanzillo 
@miq-bot add-label wip, bug