### PR TITLE
fix cli set timezone doesn't work

### DIFF
--- a/lib/manageiq/appliance_console/cli.rb
+++ b/lib/manageiq/appliance_console/cli.rb
@@ -272,6 +272,7 @@ module ApplianceConsole
 
     def set_time_zone
       timezone_config = ManageIQ::ApplianceConsole::TimezoneConfiguration.new(options[:timezone])
+      timezone_config.new_timezone = options[:timezone]
       if timezone_config.activate
         say("Timezone configured")
       else

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -666,6 +666,7 @@ describe ManageIQ::ApplianceConsole::Cli do
     it "should set timezone" do
       expect(subject).to receive(:say)
       expect(ManageIQ::ApplianceConsole::TimezoneConfiguration).to receive(:new).with("Europe/Madrid").and_return(timezone)
+      expect(timezone).to receive(:new_timezone=).with("Europe/Madrid")
       expect(timezone).to receive(:activate).and_return(true)
       subject.parse(%w(--timezone Europe/Madrid)).run
     end
@@ -673,6 +674,7 @@ describe ManageIQ::ApplianceConsole::Cli do
     it "should not set timezone" do
       expect(subject).to receive(:say)
       expect(ManageIQ::ApplianceConsole::TimezoneConfiguration).to receive(:new).with("ss/dd").and_return(timezone)
+      expect(timezone).to receive(:new_timezone=).with("ss/dd")
       expect(timezone).to receive(:activate).and_return(false)
       subject.parse(%w(--timezone ss/dd)).run
     end


### PR DESCRIPTION
Issue:
Set timezone in cli doesn't work, because the new timezone parameter isn't sent to `TimezoneConfiguration` class. It's fixed now.
BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1517897

\cc @carbonin, @yrudman, @gtanzillo 

@miq-bot add-label bug