### PR TITLE
Configure database ssl on creation

### DIFF
--- a/lib/manageiq/appliance_console/internal_database_configuration.rb
+++ b/lib/manageiq/appliance_console/internal_database_configuration.rb
@@ -99,7 +99,7 @@ module ApplianceConsole
 
     def configure_postgres
       copy_template "postgresql.conf"
-      copy_template "pg_hba.conf.erb"
+      copy_template "pg_hba.conf"
       copy_template "pg_ident.conf"
     end
 

--- a/lib/manageiq/appliance_console/internal_database_configuration.rb
+++ b/lib/manageiq/appliance_console/internal_database_configuration.rb
@@ -113,14 +113,8 @@ module ApplianceConsole
       PostgresAdmin.mount_point
     end
 
-    def copy_template(src, src_dir = self.class.postgresql_template, dest_dir = PostgresAdmin.data_directory)
-      full_src = src_dir.join(src)
-      if src.include?(".erb")
-        full_dest = dest_dir.join(src.gsub(".erb", ""))
-        File.open(full_dest, "w") { |f| f.puts ERB.new(File.read(full_src), nil, '-').result(binding) }
-      else
-        FileUtils.cp full_src, dest_dir
-      end
+    def copy_template(src)
+      FileUtils.cp(self.class.postgresql_template.join(src), PostgresAdmin.data_directory)
     end
 
     def pg_mount_point?


### PR DESCRIPTION
This PR utilizes changes made in https://github.com/ManageIQ/manageiq-appliance/pull/162 to generate ssl certs for encrypting database traffic.

It also removes conditional logic around setting the `ssl` option in postgresql.conf