### PR TITLE
Add GPT as partition table when disk size are bigger than 2 TB

### DIFF
--- a/lib/manageiq/appliance_console/logical_volume_management.rb
+++ b/lib/manageiq/appliance_console/logical_volume_management.rb
@@ -43,10 +43,10 @@ module ApplianceConsole
     def create_partition_to_fill_disk
       # Check if you need to create a GPT part table or a MSDOS one in base of
       # max size of partition table
-      max_msdos_ptable_size = 2199023255552
+      max_msdos_ptable_size = 2.terabyte
       self.disk = LinuxAdmin::Disk.local.find { |d| d.path == disk.path }
 
-      if self.disk.size  >= max_msdos_ptable_size
+      if self.disk.size >= max_msdos_ptable_size
         partition_type = 'gpt'
       else
         partition_type = 'msdos'

--- a/lib/manageiq/appliance_console/logical_volume_management.rb
+++ b/lib/manageiq/appliance_console/logical_volume_management.rb
@@ -46,11 +46,7 @@ module ApplianceConsole
       max_msdos_ptable_size = 2.terabyte
       self.disk = LinuxAdmin::Disk.local.find { |d| d.path == disk.path }
 
-      if self.disk.size >= max_msdos_ptable_size
-        partition_type = 'gpt'
-      else
-        partition_type = 'msdos'
-      end
+      partition_type = disk.size >= max_msdos_ptable_size ? 'gpt' : 'msdos'
       disk.create_partition_table(partition_type)
 
       AwesomeSpawn.run!("parted -s #{disk.path} mkpart primary 0% 100%")

--- a/spec/logical_volume_management_spec.rb
+++ b/spec/logical_volume_management_spec.rb
@@ -45,6 +45,8 @@ describe ManageIQ::ApplianceConsole::LogicalVolumeManagement do
 
       @fake_logical_volume = double(@spec_name, :path => "/dev/vg_test/lv_test")
       expect(LinuxAdmin::LogicalVolume).to receive(:create).and_return(@fake_logical_volume)
+      @dos_disk_size = 2.terabyte - 1
+      @gpt_disk_size = 2.terabyte
     end
 
     after do
@@ -53,7 +55,7 @@ describe ManageIQ::ApplianceConsole::LogicalVolumeManagement do
     end
 
     it "sets up the logical disk when mount point is not a symbolic link" do
-      expect(@disk_double).to receive(:size).and_return(2000000000000)
+      expect(@disk_double).to receive(:size).and_return(@dos_disk_size)
       expect(@disk_double).to receive(:create_partition_table).with("msdos")
       @tmp_mount_point = @config.mount_point = Pathname.new(Dir.mktmpdir)
       expect(@fstab).to receive(:write!)
@@ -71,7 +73,7 @@ describe ManageIQ::ApplianceConsole::LogicalVolumeManagement do
     end
 
     it "recreates the new mount point and sets up the logical disk when mount point is a symbolic link" do
-      expect(@disk_double).to receive(:size).and_return(2000000000000)
+      expect(@disk_double).to receive(:size).and_return(@dos_disk_size)
       expect(@disk_double).to receive(:create_partition_table).with("msdos")
       @tmp_mount_point = Pathname.new(Dir.mktmpdir)
       @config.mount_point = Pathname.new("#{Dir.tmpdir}/#{@spec_name}")
@@ -93,7 +95,7 @@ describe ManageIQ::ApplianceConsole::LogicalVolumeManagement do
     end
 
     it "skips update if mount point is in fstab when mount point is in already fstab" do
-      expect(@disk_double).to receive(:size).and_return(2000000000000)
+      expect(@disk_double).to receive(:size).and_return(@dos_disk_size)
       expect(@disk_double).to receive(:create_partition_table).with("msdos")
       @tmp_mount_point = @config.mount_point = Pathname.new(Dir.mktmpdir)
       expect(FileUtils).to_not receive(:mkdir_p).with(@config.mount_point)
@@ -114,7 +116,7 @@ describe ManageIQ::ApplianceConsole::LogicalVolumeManagement do
     end
 
     it "uses gpt partition table when disk size is over 2TB" do
-      expect(@disk_double).to receive(:size).and_return(2199023255552)
+      expect(@disk_double).to receive(:size).and_return(@gpt_disk_size)
       expect(@disk_double).to receive(:create_partition_table).with("gpt")
       @tmp_mount_point = @config.mount_point = Pathname.new(Dir.mktmpdir)
       expect(@fstab).to receive(:write!)

--- a/spec/logical_volume_management_spec.rb
+++ b/spec/logical_volume_management_spec.rb
@@ -29,7 +29,8 @@ describe ManageIQ::ApplianceConsole::LogicalVolumeManagement do
 
   describe "#setup" do
     before do
-      expect(@disk_double).to receive(:create_partition_table)
+      expect(@disk_double).to receive(:create_partition_table).with("gpt")
+      expect(@disk_double).to receive(:create_partition_table).with("msdos")
       expect(@disk_double).to receive(:partitions).and_return([:fake_partition])
       @config.disk = @disk_double
 

--- a/spec/logical_volume_management_spec.rb
+++ b/spec/logical_volume_management_spec.rb
@@ -29,8 +29,6 @@ describe ManageIQ::ApplianceConsole::LogicalVolumeManagement do
 
   describe "#setup" do
     before do
-      expect(@disk_double).to receive(:create_partition_table).with("gpt")
-      expect(@disk_double).to receive(:create_partition_table).with("msdos")
       expect(@disk_double).to receive(:partitions).and_return([:fake_partition])
       @config.disk = @disk_double
 
@@ -55,6 +53,8 @@ describe ManageIQ::ApplianceConsole::LogicalVolumeManagement do
     end
 
     it "sets up the logical disk when mount point is not a symbolic link" do
+      expect(@disk_double).to receive(:size).and_return(2000000000000)
+      expect(@disk_double).to receive(:create_partition_table).with("msdos")
       @tmp_mount_point = @config.mount_point = Pathname.new(Dir.mktmpdir)
       expect(@fstab).to receive(:write!)
       expect(FileUtils).to_not receive(:mkdir_p).with(@config.mount_point)
@@ -71,6 +71,8 @@ describe ManageIQ::ApplianceConsole::LogicalVolumeManagement do
     end
 
     it "recreates the new mount point and sets up the logical disk when mount point is a symbolic link" do
+      expect(@disk_double).to receive(:size).and_return(2000000000000)
+      expect(@disk_double).to receive(:create_partition_table).with("msdos")
       @tmp_mount_point = Pathname.new(Dir.mktmpdir)
       @config.mount_point = Pathname.new("#{Dir.tmpdir}/#{@spec_name}")
       FileUtils.ln_s(@tmp_mount_point, @config.mount_point)
@@ -91,6 +93,8 @@ describe ManageIQ::ApplianceConsole::LogicalVolumeManagement do
     end
 
     it "skips update if mount point is in fstab when mount point is in already fstab" do
+      expect(@disk_double).to receive(:size).and_return(2000000000000)
+      expect(@disk_double).to receive(:create_partition_table).with("msdos")
       @tmp_mount_point = @config.mount_point = Pathname.new(Dir.mktmpdir)
       expect(FileUtils).to_not receive(:mkdir_p).with(@config.mount_point)
       expect(AwesomeSpawn).to receive(:run!)
@@ -102,6 +106,24 @@ describe ManageIQ::ApplianceConsole::LogicalVolumeManagement do
 
       @config.setup
 
+      expect(@config.partition).to eq(:fake_partition)
+      expect(@config.physical_volume).to eq(:fake_physical_volume)
+      expect(@config.volume_group).to eq(:fake_volume_group)
+      expect(@config.logical_volume).to eq(@fake_logical_volume)
+      expect(@fstab.entries.count).to eq(1)
+    end
+
+    it "uses gpt partition table when disk size is over 2TB" do
+      expect(@disk_double).to receive(:size).and_return(2199023255552)
+      expect(@disk_double).to receive(:create_partition_table).with("gpt")
+      @tmp_mount_point = @config.mount_point = Pathname.new(Dir.mktmpdir)
+      expect(@fstab).to receive(:write!)
+      expect(FileUtils).to_not receive(:mkdir_p).with(@config.mount_point)
+      expect(AwesomeSpawn).to receive(:run!)
+        .with("mount",
+              :params => {"-t" => @config.filesystem_type, nil => ["/dev/vg_test/lv_test", @config.mount_point]})
+
+      @config.setup
       expect(@config.partition).to eq(:fake_partition)
       expect(@config.physical_volume).to eq(:fake_physical_volume)
       expect(@config.volume_group).to eq(:fake_volume_group)


### PR DESCRIPTION
This is a follow up on https://github.com/ManageIQ/manageiq-appliance_console/pull/11 to fix the issue that can't install CloudForms on a disk larger than 2TB. Because dos partition table support upto 2TB disk, and need to use GPT partition table instead. The fix is almost all done by J. Parrill and specs by Nick LaMuro, and with some comments from Nick Carboni and Jason Frey. I just put them together into this PR.

BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1506997

\cc @yrudman @carbonin @gtanzillo 
@miq-bot add-label bug