### PR TITLE
Implement set date time in cli

### DIFF
--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -688,20 +688,17 @@ describe ManageIQ::ApplianceConsole::Cli do
     end
 
     it "should set auto sync when datetime option is auto" do
-      expect(datetime).not_to receive(:manual_time_sync=)
-      expect(datetime).not_to receive(:new_date=)
-      expect(datetime).not_to receive(:new_time=)
       expect(datetime).to receive(:activate).and_return(true)
       subject.parse(%w(--datetime auto)).run
+      expect(datetime.manual_time_sync).to be_falsy
     end
 
     it "should set date time according to given date time" do
-      expect(datetime).to receive(:manual_time_sync=).with(true)
-      expect(datetime).to receive(:new_date=).with("2017-06-08")
-      expect(datetime).to receive(:new_time=).with("09:00:00")
-      expect(subject).to receive(:date_time_valid?).with(datetime).and_return(true)
       expect(datetime).to receive(:activate).and_return(true)
       subject.parse(%w(--datetime 2017-06-08T09:00:00)).run
+      expect(datetime.manual_time_sync).to be_truthy
+      expect(datetime.new_date).to eq("2017-06-08")
+      expect(datetime.new_time).to eq("09:00:00")
     end
   end
 

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -680,6 +680,31 @@ describe ManageIQ::ApplianceConsole::Cli do
     end
   end
 
+  context "#set_date_time" do
+    let(:datetime) { ManageIQ::ApplianceConsole::DateTimeConfiguration.new }
+
+    before do
+      expect(ManageIQ::ApplianceConsole::DateTimeConfiguration).to receive(:new).and_return(datetime)
+    end
+
+    it "should set auto sync when datetime option is auto" do
+      expect(datetime).not_to receive(:manual_time_sync=)
+      expect(datetime).not_to receive(:new_date=)
+      expect(datetime).not_to receive(:new_time=)
+      expect(datetime).to receive(:activate).and_return(true)
+      subject.parse(%w(--datetime auto)).run
+    end
+
+    it "should set date time according to given date time" do
+      expect(datetime).to receive(:manual_time_sync=).with(true)
+      expect(datetime).to receive(:new_date=).with("2017-06-08")
+      expect(datetime).to receive(:new_time=).with("09:00:00")
+      expect(subject).to receive(:date_time_valid?).with(datetime).and_return(true)
+      expect(datetime).to receive(:activate).and_return(true)
+      subject.parse(%w(--datetime 2017-06-08T09:00:00)).run
+    end
+  end
+
   context "#config_db_hourly_maintenance" do
     before do
       @test_hourly_cron = "#{Dir.tmpdir}/miq-pg-maintenance-hourly.cron"


### PR DESCRIPTION
As mentioned in https://github.com/ManageIQ/manageiq-appliance_console/issues/7
Now user can use `--datetime` option to configure date time, (optionally used with other options)
Usage:
To set a given time and date:
`appliance_console_cli --datetime YYYY-MM-DD_HH:MM:SS`
Or to set datetime autosync:
`appliance_console_cli --datetime auto`

\cc @carbonin 
@miq-bot add-label enhancement