### PR TITLE
Update incorrect comment at module/class end

### DIFF
--- a/lib/manageiq/appliance_console/database_maintenance.rb
+++ b/lib/manageiq/appliance_console/database_maintenance.rb
@@ -30,6 +30,6 @@ module ApplianceConsole
       self.executed_periodic_action = periodic.activate
       executed_hourly_action || executed_periodic_action
     end
-  end # class DatabaseMaintenance < DatabaseConfiguration
+  end # class DatabaseMaintenance
 end # module ApplianceConsole
 end

--- a/lib/manageiq/appliance_console/database_maintenance_hourly.rb
+++ b/lib/manageiq/appliance_console/database_maintenance_hourly.rb
@@ -53,6 +53,6 @@ module ApplianceConsole
         f.write("exit 0\n")
       end
     end
-  end # class DatabaseMaintenance < DatabaseConfiguration
+  end # class DatabaseMaintenanceHourly
 end # module ApplianceConsole
 end

--- a/lib/manageiq/appliance_console/database_replication.rb
+++ b/lib/manageiq/appliance_console/database_replication.rb
@@ -142,6 +142,6 @@ Replication Server Configuration
         :password => database_password
       }
     end
-  end # class DatabaseReplication < DatabaseConfiguration
+  end # class DatabaseReplication
 end # module ApplianceConsole
 end

--- a/lib/manageiq/appliance_console/date_time_configuration.rb
+++ b/lib/manageiq/appliance_console/date_time_configuration.rb
@@ -112,6 +112,6 @@ Date and Time Configuration
       logger.error("Failed to apply time configuration: #{e.message}")
       false
     end
-  end # class TimezoneConfiguration
+  end # class DateTimeConfiguration
 end # module ApplianceConsole
 end


### PR DESCRIPTION
A trivial fix to update incorrect comment at all module/class end. I go through all files in this repo and this PR includes all of outdated comment of this kind. For class/module definitions that don't end with this kind of comment, keep intact.

\cc @carbonin