### PR TITLE
Allow IPv4, IPv6 or none as secondary DNS when configuring IPv6

### DIFF
--- a/bin/appliance_console
+++ b/bin/appliance_console
@@ -225,7 +225,7 @@ Static Network Configuration
           new_prefix = ask_for_integer('IPv6 prefix length', 1..127, eth0.prefix6 || 64)
           new_gw = ask_for_ipv6('Default gateway', eth0.gateway6)
           new_dns1 = ask_for_ip('Primary DNS', dns1)
-          new_dns2 = ask_for_ipv6_or_none("Secondary DNS (Enter 'none' for no value)", dns2)
+          new_dns2 = ask_for_ip_or_none("Secondary DNS (Enter 'none' for no value)", dns2)
 
           new_search_order = ask_for_many('domain', 'Domain search order', order)
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1527915
https://bugzilla.redhat.com/show_bug.cgi?id=1530722