### PR TITLE
make help message more clear what actions can be taken

### DIFF
--- a/lib/manageiq/appliance_console/cli.rb
+++ b/lib/manageiq/appliance_console/cli.rb
@@ -150,7 +150,7 @@ module ApplianceConsole
         opt :postgres_server_cert, "install certs for postgres server", :type => :boolean
         opt :http_cert,            "install certs for http server",     :type => :boolean
         opt :extauth_opts,         "External Authentication Options",   :type => :string
-        opt :server,               "Server status",                     :type => :string
+        opt :server,               "{start|stop|restart} actions on evmserverd Server",   :type => :string
       end
       Trollop.die :region, "needed when setting up a local database" if region_number_required? && options[:region].nil?
       self


### PR DESCRIPTION
Hi 
I had to look at cli.rb source to see which action can be provided to "--server" option. 
This simple PR will tell user exactly what actions are supported.