### PR TITLE
Check the current database connections before running the restore

### DIFF
--- a/bin/appliance_console
+++ b/bin/appliance_console
@@ -394,6 +394,14 @@ Static Network Configuration
         task_params = []
         uri = nil
 
+        connections = ManageIQ::ApplianceConsole::Utilities.db_connections - 1
+        if connections > 0
+          say("\nDatabase restore failed")
+          say("\nThere #{connections > 1 ? "are #{connections} connections" : "is 1 connection"} preventing a database restore")
+          press_any_key
+          raise MiqSignalError
+        end
+
         # TODO: merge into 1 prompt
         case ask_with_menu("Restore Database File", RESTORE_OPTIONS, RESTORE_LOCAL, nil)
         when RESTORE_LOCAL
@@ -435,10 +443,6 @@ Static Network Configuration
           if rake_success && delete_agreed
             say("\nRemoving the database restore file #{DB_RESTORE_FILE}...")
             File.delete(DB_RESTORE_FILE)
-          elsif !rake_success
-            say("\nDatabase restore failed")
-            connections = ManageIQ::ApplianceConsole::Utilities.db_connections - 1
-            say("\nThere #{connections > 1 ? "are #{connections} connections" : "is 1 connection"} preventing a database restore") if connections > 0
           end
         end
         press_any_key


### PR DESCRIPTION
This allows us to abort and inform the user before taking any potentially destructive actions

https://bugzilla.redhat.com/show_bug.cgi?id=1534999