### PR TITLE
Remove restore connection checking

### DIFF
--- a/bin/appliance_console
+++ b/bin/appliance_console
@@ -435,6 +435,8 @@ Static Network Configuration
           if rake_success && delete_agreed
             say("\nRemoving the database restore file #{DB_RESTORE_FILE}...")
             File.delete(DB_RESTORE_FILE)
+          elsif !rake_success
+            say("\nDatabase restore failed. Check the logs for more information")
           end
         end
         press_any_key

--- a/bin/appliance_console
+++ b/bin/appliance_console
@@ -394,14 +394,6 @@ Static Network Configuration
         task_params = []
         uri = nil
 
-        connections = ManageIQ::ApplianceConsole::Utilities.db_connections - 1
-        if connections > 0
-          say("\nDatabase restore failed")
-          say("\nThere #{connections > 1 ? "are #{connections} connections" : "is 1 connection"} preventing a database restore")
-          press_any_key
-          raise MiqSignalError
-        end
-
         # TODO: merge into 1 prompt
         case ask_with_menu("Restore Database File", RESTORE_OPTIONS, RESTORE_LOCAL, nil)
         when RESTORE_LOCAL


### PR DESCRIPTION
As of https://github.com/ManageIQ/manageiq/pull/16942 these checks are implemented in the core application so we don't need to confuse things by doing them here.

This also helps in fixing https://bugzilla.redhat.com/show_bug.cgi?id=1540686 by removing the check which fails when pglogical is active when trying to do a restore.