### PR TITLE
db_maintenance was previously removed from en.yml

### DIFF
--- a/locales/appliance/en.yml
+++ b/locales/appliance/en.yml
@@ -10,7 +10,6 @@ en:
     - dbrestore
     - db_config
     - db_replication
-    - db_maintenance
     - log_config
     - failover_monitor
     - httpdauth

--- a/locales/container/en.yml
+++ b/locales/container/en.yml
@@ -8,7 +8,6 @@ en:
     - dbrestore
     - db_config
     - db_replication
-    - db_maintenance
     - failover_monitor
     - key_gen
     - evmstop


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1571246

Fixes: translation missing: en.advanced_settings.db_maintenance in
Advanced Settings menu of the appliance console.

The DB maintenance menu was removed in:
https://github.com/ManageIQ/manageiq-appliance_console/pull/32

It was replaced with:

https://github.com/ManageIQ/manageiq/pull/16929
https://github.com/ManageIQ/manageiq/pull/16940