### PR TITLE
Always configure database.yml and encryption key

### DIFF
--- a/bin/appliance_console
+++ b/bin/appliance_console
@@ -73,6 +73,24 @@ CLOUD_INIT_DISABLE_NETWORK_CONFIG = "network: {config: disabled}\n".freeze
 
 module ManageIQ
 module ApplianceConsole
+  def ensure_key_configured
+    key_config = ManageIQ::ApplianceConsole::KeyConfiguration.new
+    unless key_config.key_exist?
+      say "No encryption key found.\n"
+      say "For migrations, copy encryption key from a hardened appliance."
+      say "For worker and multi-region setups, copy key from another appliance.\n"
+      say "If this is your first appliance, just generate one now.\n\n"
+
+      if key_config.ask_question_loop
+        say("\nEncryption key now configured.\n\n")
+      else
+        say("\nEncryption key not configured.")
+        press_any_key
+        raise MiqSignalError
+      end
+    end
+  end
+
   eth0 = LinuxAdmin::NetworkInterface.new(NETWORK_INTERFACE)
   # Because it takes a few seconds, get the region once in the outside loop
   region = ManageIQ::ApplianceConsole::DatabaseConfiguration.region
@@ -457,21 +475,7 @@ Static Network Configuration
       when I18n.t("advanced_settings.db_config")
         say("#{selection}\n\n")
 
-        key_config = ManageIQ::ApplianceConsole::KeyConfiguration.new
-        unless key_config.key_exist?
-          say "No encryption key found.\n"
-          say "For migrations, copy encryption key from a hardened appliance."
-          say "For worker and multi-region setups, copy key from another appliance.\n"
-          say "If this is your first appliance, just generate one now.\n\n"
-
-          if key_config.ask_question_loop
-            say("\nEncryption key now configured.\n\n")
-          else
-            say("\nEncryption key not configured.")
-            press_any_key
-            raise MiqSignalError
-          end
-        end
+        ensure_key_configured
 
         options = {
           "Create Internal Database"           => "create_internal",
@@ -524,6 +528,7 @@ Static Network Configuration
         when "standby"
           db_replication = ManageIQ::ApplianceConsole::DatabaseReplicationStandby.new
           logger.info("Configuring Server as Standby")
+          ensure_key_configured
         end
 
         if db_replication.ask_questions && db_replication.activate

--- a/lib/manageiq/appliance_console/database_replication_standby.rb
+++ b/lib/manageiq/appliance_console/database_replication_standby.rb
@@ -63,6 +63,7 @@ module ApplianceConsole
       stop_repmgrd
       initialize_postgresql_disk if disk
       PostgresAdmin.prep_data_directory if disk || resync_data
+      save_database_yml
       generate_cluster_name &&
         create_config_file(standby_host) &&
         clone_standby_server &&
@@ -142,6 +143,10 @@ module ApplianceConsole
     end
 
     private
+
+    def save_database_yml
+      InternalDatabaseConfiguration.new(:password => database_password).save
+    end
 
     def record_for_node_number
       c = PG::Connection.new(primary_connection_hash)

--- a/lib/manageiq/appliance_console/internal_database_configuration.rb
+++ b/lib/manageiq/appliance_console/internal_database_configuration.rb
@@ -41,7 +41,7 @@ module ApplianceConsole
       end
       initialize_postgresql_disk if disk
       initialize_postgresql
-      return super if run_as_evm_server
+      run_as_evm_server ? (return super) : save
       true
     end
 

--- a/spec/database_replication_standby_spec.rb
+++ b/spec/database_replication_standby_spec.rb
@@ -111,6 +111,7 @@ describe ManageIQ::ApplianceConsole::DatabaseReplicationStandby do
     before do
       expect(subject).to receive(:stop_postgres)
       expect(subject).to receive(:stop_repmgrd)
+      expect(subject).to receive(:save_database_yml)
       expect(subject).to receive(:generate_cluster_name).and_return(true)
       expect(subject).to receive(:create_config_file).and_return(true)
       expect(subject).to receive(:clone_standby_server).and_return(true)
@@ -333,6 +334,16 @@ describe ManageIQ::ApplianceConsole::DatabaseReplicationStandby do
         expect(PG::Connection).to receive(:new).and_return(connection)
         expect(connection).to receive(:exec_params).and_raise(PG::Error)
         expect(subject.node_number_valid?).to be_falsey
+      end
+    end
+
+    context "#save_database_yml (private)" do
+      it "passes the configured password" do
+        subject.database_password = "supersecret"
+        conf = double("InternalDatabaseConfiguration")
+        expect(ManageIQ::ApplianceConsole::InternalDatabaseConfiguration).to receive(:new).with(:password => "supersecret").and_return(conf)
+        expect(conf).to receive(:save)
+        subject.send(:save_database_yml)
       end
     end
   end


### PR DESCRIPTION
We need these to do proper connection checking when restoring a database.

Since database restore should work on appliances which are not running the application (standalone dbs and standby databases) we should configure these even if the application won't be running.

https://bugzilla.redhat.com/show_bug.cgi?id=1561075