### PR TITLE
[WIP] Make cancel less confusing

### DIFF
--- a/bin/appliance_console
+++ b/bin/appliance_console
@@ -62,17 +62,18 @@ MiqPassword.key_root = ManageIQ::ApplianceConsole::RAILS_ROOT.join("certs").to_s
 
 # Load appliance_console libraries
 include ManageIQ::ApplianceConsole::Prompts
+CANCEL = "Cancel".freeze
 
 # Restore database choices
 RESTORE_LOCAL   = "Local file".freeze
 RESTORE_NFS     = "Network File System (NFS)".freeze
 RESTORE_SMB     = "Samba (SMB)".freeze
-RESTORE_OPTIONS = [RESTORE_LOCAL, RESTORE_NFS, RESTORE_SMB, ManageIQ::ApplianceConsole::CANCEL].freeze
+RESTORE_OPTIONS = [RESTORE_LOCAL, RESTORE_NFS, RESTORE_SMB, CANCEL].freeze
 
 # Restart choices
 RE_RESTART  = "Restart".freeze
 RE_DELLOGS  = "Restart and Clean Logs".freeze
-RE_OPTIONS  = [RE_RESTART, RE_DELLOGS, ManageIQ::ApplianceConsole::CANCEL].freeze
+RE_OPTIONS  = [RE_RESTART, RE_DELLOGS, CANCEL].freeze
 
 NETWORK_INTERFACE = "eth0".freeze
 CLOUD_INIT_NETWORK_CONFIG_FILE = "/etc/cloud/cloud.cfg.d/99_miq_disable_network_config.cfg".freeze
@@ -550,7 +551,7 @@ Static Network Configuration
 
       when I18n.t("advanced_settings.restart")
         case ask_with_menu("Restart Option", RE_OPTIONS, nil, false)
-        when ManageIQ::ApplianceConsole::CANCEL
+        when CANCEL
           # don't do anything
         when RE_RESTART
           if are_you_sure?("restart the appliance now")

--- a/bin/appliance_console
+++ b/bin/appliance_console
@@ -64,12 +64,6 @@ MiqPassword.key_root = ManageIQ::ApplianceConsole::RAILS_ROOT.join("certs").to_s
 include ManageIQ::ApplianceConsole::Prompts
 CANCEL = "Cancel".freeze
 
-# Restore database choices
-RESTORE_LOCAL   = "Local file".freeze
-RESTORE_NFS     = "Network File System (NFS)".freeze
-RESTORE_SMB     = "Samba (SMB)".freeze
-RESTORE_OPTIONS = [RESTORE_LOCAL, RESTORE_NFS, RESTORE_SMB, CANCEL].freeze
-
 # Restart choices
 RE_RESTART  = "Restart".freeze
 RE_DELLOGS  = "Restart and Clean Logs".freeze

--- a/lib/manageiq/appliance_console/database_admin.rb
+++ b/lib/manageiq/appliance_console/database_admin.rb
@@ -8,6 +8,7 @@ module ManageIQ
       LOCAL_FILE     = "Local file".freeze
       NFS_FILE       = "Network File System (NFS)".freeze
       SMB_FILE       = "Samba (SMB)".freeze
+      CANCEL         = "Cancel".freeze
       FILE_OPTIONS   = [LOCAL_FILE, NFS_FILE, SMB_FILE, CANCEL].freeze
 
       DB_RESTORE_FILE      = "/tmp/evm_db.backup".freeze

--- a/lib/manageiq/appliance_console/prompts.rb
+++ b/lib/manageiq/appliance_console/prompts.rb
@@ -2,8 +2,6 @@ require 'resolv'
 
 module ManageIQ
 module ApplianceConsole
-  CANCEL = 'Cancel'.freeze
-
   module Prompts
     CLEAR_CODE    = `clear`
     IPV4_REGEXP   = Resolv::IPv4::Regex

--- a/lib/manageiq/appliance_console/timezone_configuration.rb
+++ b/lib/manageiq/appliance_console/timezone_configuration.rb
@@ -34,8 +34,8 @@ module ApplianceConsole
       current_item = timezone_hash
 
       while current_item.is_a?(Hash)
-        selection = ask_with_menu("Geographic Location", current_item.keys, nil, false)
-        return false if selection == CANCEL
+        selection = ask_with_menu("Geographic Location", current_item.keys << "Cancel", nil, false)
+        return false if selection == "Cancel"
         current_item = current_item[selection]
       end
 

--- a/spec/timezone_configuration_spec.rb
+++ b/spec/timezone_configuration_spec.rb
@@ -30,7 +30,7 @@ describe ManageIQ::ApplianceConsole::TimezoneConfiguration do
 
     it "prompts once for non-nested timezones" do
       expect(subject).to receive(:ask_with_menu).once
-        .with("Geographic Location", %w(Africa America UTC), nil, false)
+        .with("Geographic Location", %w(Africa America UTC Cancel), nil, false)
         .and_return("UTC")
 
       expect(subject.ask_for_timezone).to be true
@@ -40,13 +40,13 @@ describe ManageIQ::ApplianceConsole::TimezoneConfiguration do
 
     it "prompts multiple times for nested timezones" do
       expect(subject).to receive(:ask_with_menu)
-        .with("Geographic Location", %w(Africa America UTC), nil, false)
+        .with("Geographic Location", %w(Africa America UTC Cancel), nil, false)
         .and_return("America").ordered
       expect(subject).to receive(:ask_with_menu)
-        .with("Geographic Location", ["Argentina"], nil, false)
+        .with("Geographic Location", %w(Argentina Cancel), nil, false)
         .and_return("Argentina").ordered
       expect(subject).to receive(:ask_with_menu)
-        .with("Geographic Location", ["Buenos_Aires"], nil, false)
+        .with("Geographic Location", %w(Buenos_Aires Cancel), nil, false)
         .and_return("Buenos_Aires").ordered
 
       expect(subject.ask_for_timezone).to be true


### PR DESCRIPTION
This should only be needed in the main console file. It wasn't being used in `prompts.rb` at all and it wasn't clear how it was defined in `timezone_configuration.rb`