### PR TITLE
Add dbdump action

### DIFF
--- a/bin/appliance_console
+++ b/bin/appliance_console
@@ -400,6 +400,10 @@ Static Network Configuration
         db_admin = ManageIQ::ApplianceConsole::DatabaseAdmin.new(:backup)
         db_admin.ask_questions && db_admin.activate
 
+      when I18n.t("advanced_settings.dbdump")
+        db_admin = ManageIQ::ApplianceConsole::DatabaseAdmin.new(:dump)
+        db_admin.ask_questions && db_admin.activate
+
       when I18n.t("advanced_settings.dbrestore")
         db_admin = ManageIQ::ApplianceConsole::DatabaseAdmin.new(:restore)
         db_admin.ask_questions && db_admin.activate

--- a/lib/manageiq/appliance_console/database_admin.rb
+++ b/lib/manageiq/appliance_console/database_admin.rb
@@ -18,6 +18,14 @@ module ManageIQ
         Example: 'mydomain.com/user'
       PROMPT
 
+      DB_DUMP_WARNING = <<-WARN.strip_heredoc
+        WARNING:  This is not the recommended and supported way of running a
+        database backup, and is strictly meant for exporting a database for
+        support/debugging purposes!
+
+
+      WARN
+
       attr_reader :action, :backup_type, :task, :task_params, :delete_agree, :uri
 
       def initialize(action = :restore, input = $stdin, output = $stdout)
@@ -29,6 +37,7 @@ module ManageIQ
 
       def ask_questions
         setting_header
+        say(DB_DUMP_WARNING) if action == :dump
         ask_file_location
       end
 

--- a/lib/manageiq/appliance_console/database_admin.rb
+++ b/lib/manageiq/appliance_console/database_admin.rb
@@ -103,7 +103,7 @@ module ManageIQ
 
       def file_menu_args
         [
-          action == :restore ? "Restore Database File" : "Backup Output File Name",
+          action == :restore ? "Restore Database File" : "#{action.capitalize} Output File Name",
           FILE_OPTIONS,
           LOCAL_FILE,
           nil
@@ -120,7 +120,7 @@ module ManageIQ
         if action == :restore
           "location of the local restore file"
         else
-          "location to save the backup file to"
+          "location to save the #{action} file to"
         end
       end
 
@@ -128,14 +128,19 @@ module ManageIQ
         prompt  = if action == :restore
                     "location of the remote backup file"
                   else
-                    "location to save the remote backup file to"
+                    "location to save the remote #{action} file to"
                   end
         prompt += "\nExample: #{SAMPLE_URLS[remote_type]}"
         [prompt, remote_type]
       end
 
       def processing_message
-        say("\n#{action == :restore ? "Restoring the database" : "Running Database backup to #{uri}"}...")
+        msg = if action == :restore
+                "\nRestoring the database..."
+              else
+                "\nRunning Database #{action} to #{uri}..."
+              end
+        say(msg)
       end
 
       def run_rake

--- a/locales/appliance/en.yml
+++ b/locales/appliance/en.yml
@@ -8,6 +8,7 @@ en:
     - timezone
     - datetime
     - dbbackup
+    - dbdump
     - dbrestore
     - db_config
     - db_replication
@@ -26,6 +27,7 @@ en:
     timezone: Set Timezone
     datetime: Set Date and Time
     dbbackup: Create Database Backup
+    dbdump: Create Database Dump
     dbrestore: Restore Database From Backup
     db_config: Configure Database
     db_replication: Configure Database Replication

--- a/spec/database_admin_spec.rb
+++ b/spec/database_admin_spec.rb
@@ -817,5 +817,382 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       end
     end
   end
+
+  context "for DB dump" do
+    subject { described_class.new(:dump, input, output) }
+
+    describe "#ask_questions" do
+      it "asks for file location" do
+        expect(subject).to receive(:say).with("Create Database Dump\n\n")
+        expect(subject).to receive(:ask_file_location)
+
+        subject.ask_questions
+      end
+    end
+
+    describe "#activate" do
+      it "asks to delete backup and runs dump" do
+        expect(subject).to receive(:clear_screen)
+        expect(subject).to receive(:say).with("Create Database Dump\n\n")
+        expect(subject).to receive(:ask_to_delete_backup_after_restore)
+        expect(subject).to receive(:confirm_and_execute)
+
+        subject.activate
+      end
+    end
+
+    describe "#ask_file_location" do
+      it "displays the menu" do
+        expect(subject).to receive(:ask_local_file_options).once
+        say ""
+        subject.ask_file_location
+        expect_output <<-PROMPT.strip_heredoc.chomp + " "
+          Dump Output File Name
+
+          1) Local file
+          2) Network File System (NFS)
+          3) Samba (SMB)
+          4) Cancel
+
+          Choose the dump output file name: |1|
+        PROMPT
+      end
+
+      it "defaults to local file" do
+        expect(subject).to receive(:ask_local_file_options).once
+        say ""
+        subject.ask_file_location
+        expect(subject.backup_type).to eq(described_class::LOCAL_FILE)
+      end
+
+      it "calls #ask_local_file_options when choosen" do
+        expect(subject).to receive(:ask_local_file_options).once
+        say "1"
+        subject.ask_file_location
+        expect(subject.backup_type).to eq(described_class::LOCAL_FILE)
+      end
+
+      it "calls #ask_nfs_file_options when choosen" do
+        expect(subject).to receive(:ask_nfs_file_options).once
+        say "2"
+        subject.ask_file_location
+        expect(subject.backup_type).to eq(described_class::NFS_FILE)
+      end
+
+      it "calls #ask_smb_file_options when choosen" do
+        expect(subject).to receive(:ask_smb_file_options).once
+        say "3"
+        subject.ask_file_location
+        expect(subject.backup_type).to eq(described_class::SMB_FILE)
+      end
+
+      it "cancels when CANCEL option is choosen" do
+        say "4"
+        expect { subject.ask_file_location }.to raise_error signal_error
+      end
+    end
+
+    describe "#ask_local_file_options" do
+      let(:file)      { Tempfile.new("foo.dump").tap(&:close) }
+      let(:prmpt)     { "location to save the dump file to" }
+      let(:default)   { described_class::DB_RESTORE_FILE }
+      let(:errmsg)    { "file that exists" }
+
+      context "with no filename given" do
+        before do
+          # stub validator for default answer, since it probably doesn't exist on
+          # the machine running these tests.
+          stub_const("#{described_class.name}::LOCAL_FILE_VALIDATOR", ->(_) { true })
+
+          say ""
+          subject.ask_local_file_options
+        end
+
+        it "sets @uri to the default filename" do
+          expect(subject.uri).to eq(default)
+        end
+      end
+
+      context "with a valid filename given" do
+        before do
+          say file.path.to_s
+          subject.ask_local_file_options
+        end
+
+        it "sets @uri to point to the local file" do
+          expect(subject.uri).to eq(file.path)
+        end
+
+        it "sets @task to point to 'evm:db:dump:local'" do
+          expect(subject.task).to eq("evm:db:dump:local")
+        end
+
+        it "sets @task_params to point to the local file" do
+          expect(subject.task_params).to eq(["--", {:local_file => file.path}])
+        end
+      end
+
+      context "with an invalid filename given" do
+        let(:bad_filename) { "#{file.path}.bad_mmkay" }
+
+        before do
+          say [bad_filename, file.path.to_s]
+          subject.ask_local_file_options
+        end
+
+        it "reprompts the user and then properly sets the options" do
+          error = "Please provide #{errmsg}"
+          expect_heard ["Enter the #{prmpt}: ", error, prompt]
+
+          expect(subject.uri).to         eq(file.path)
+          expect(subject.task).to        eq("evm:db:dump:local")
+          expect(subject.task_params).to eq(["--", {:local_file => file.path}])
+        end
+      end
+    end
+
+    describe "#ask_nfs_file_options" do
+      let(:example_uri) { subject.sample_url('nfs') }
+      let(:prmpt)       { "location to save the remote dump file to\nExample: #{example_uri}" }
+      let(:errmsg)      { "a valid URI" }
+
+      context "with a valid uri given" do
+        before do
+          say example_uri
+          subject.ask_nfs_file_options
+        end
+
+        it "sets @uri to point to the nfs file" do
+          expect(subject.uri).to eq(example_uri)
+        end
+
+        it "sets @task to point to 'evm:db:dump:remote'" do
+          expect(subject.task).to eq("evm:db:dump:remote")
+        end
+
+        it "sets @task_params to point to the nfs file" do
+          expect(subject.task_params).to eq(["--", {:uri => example_uri}])
+        end
+      end
+
+      context "with an invalid uri given" do
+        let(:bad_uri) { "file://host.mydomain.com/path/to/file" }
+
+        before do
+          say [bad_uri, example_uri]
+          subject.ask_nfs_file_options
+        end
+
+        it "reprompts the user and then properly sets the options" do
+          error = "Please provide #{errmsg}"
+          expect_heard ["Enter the #{prmpt}: ", error, prompt]
+
+          expect(subject.uri).to         eq(example_uri)
+          expect(subject.task).to        eq("evm:db:dump:remote")
+          expect(subject.task_params).to eq(["--", {:uri => example_uri}])
+        end
+      end
+    end
+
+    describe "#ask_smb_file_options" do
+      let(:example_uri) { subject.sample_url('smb') }
+      let(:user)        { 'example.com/admin' }
+      let(:pass)        { 'supersecret' }
+      let(:uri_prompt)  { "Enter the location to save the remote dump file to\nExample: #{example_uri}" }
+      let(:user_prompt) { "Enter the username with access to this file.\nExample: 'mydomain.com/user'" }
+      let(:pass_prompt) { "Enter the password for #{user}" }
+      let(:errmsg)      { "a valid URI" }
+
+      let(:expected_task_params) do
+        [
+          "--",
+          {
+            :uri          => example_uri,
+            :uri_username => user,
+            :uri_password => pass
+          }
+        ]
+      end
+
+      context "with a valid uri, username, and password given" do
+        before do
+          say [example_uri, user, pass]
+          subject.ask_smb_file_options
+        end
+
+        it "sets @uri to point to the smb file" do
+          expect(subject.uri).to eq(example_uri)
+        end
+
+        it "sets @task to point to 'evm:db:dump:local'" do
+          expect(subject.task).to eq("evm:db:dump:remote")
+        end
+
+        it "sets @task_params to point to the smb file, username, and password" do
+          expect(subject.task_params).to eq(expected_task_params)
+        end
+      end
+
+      context "with a invalid uri given" do
+        let(:bad_uri) { "nfs://host.mydomain.com/path/to/file" }
+
+        before do
+          say [bad_uri, example_uri, user, pass]
+          subject.ask_smb_file_options
+        end
+
+        it "reprompts the user and then properly sets the options" do
+          error = "Please provide #{errmsg}"
+
+          expect_readline_question_asked uri_prompt
+          expect_readline_question_asked user_prompt
+          expect_heard [
+            uri_prompt,
+            error,
+            prompt,
+            "#{pass_prompt}: ***********\n"
+          ]
+
+          expect(subject.uri).to         eq(example_uri)
+          expect(subject.task).to        eq("evm:db:dump:remote")
+          expect(subject.task_params).to eq(expected_task_params)
+        end
+      end
+    end
+
+    describe "#ask_to_delete_backup_after_restore" do
+      context "when @backup_type is LOCAL_FILE" do
+        let(:uri) { described_class::DB_RESTORE_FILE }
+
+        before do
+          subject.instance_variable_set(:@uri, uri)
+          subject.instance_variable_set(:@backup_type, described_class::LOCAL_FILE)
+        end
+
+        it "no-ops" do
+          subject.ask_to_delete_backup_after_restore
+          expect_output ""
+        end
+      end
+
+      context "when @backup_type not is LOCAL_FILE" do
+        let(:uri) { described_class::DB_RESTORE_FILE }
+
+        before do
+          subject.instance_variable_set(:@uri, uri)
+          subject.instance_variable_set(:@backup_type, described_class::NFS_FILE)
+        end
+
+        it "no-ops" do
+          subject.ask_to_delete_backup_after_restore
+          expect_output ""
+        end
+      end
+    end
+
+    describe "#confirm_and_execute" do
+      let(:uri)             { "/tmp/my_db.dump" }
+      let(:agree)           { "y" }
+      let(:task)            { "evm:db:dump:local" }
+      let(:task_params)     { ["--", { :uri => uri }] }
+      let(:utils)           { ManageIQ::ApplianceConsole::Utilities }
+
+      before do
+        subject.instance_variable_set(:@uri, uri)
+        subject.instance_variable_set(:@delete_agree, true)
+        expect(STDIN).to receive(:getc)
+        allow(File).to receive(:delete)
+      end
+
+      def confirm_and_execute
+        say agree
+        subject.confirm_and_execute
+      end
+
+      context "when it is successful" do
+        before { expect(utils).to receive(:rake).and_return(true) }
+
+        it "does not delete the dump file" do
+          expect(File).to receive(:delete).with(uri).never
+          confirm_and_execute
+        end
+
+        it "outputs waits for user to press a key to continue" do
+          confirm_and_execute
+          expect_output <<-PROMPT.strip_heredoc
+
+            Running Database dump to /tmp/my_db.dump...
+
+            Press any key to continue.
+          PROMPT
+        end
+
+        context "without a delete agreement" do
+          before do
+            subject.instance_variable_set(:@delete_agree, false)
+          end
+
+          it "does not delete the dump file" do
+            expect(File).to receive(:delete).with(uri).never
+            confirm_and_execute
+          end
+
+          it "outputs waits for user to press a key to continue" do
+            confirm_and_execute
+            expect_output <<-PROMPT.strip_heredoc
+
+              Running Database dump to /tmp/my_db.dump...
+
+              Press any key to continue.
+            PROMPT
+          end
+        end
+      end
+
+      context "when it is not successful" do
+        before { expect(utils).to receive(:rake).and_return(false) }
+
+        it "does not delete the dump file" do
+          expect(File).to receive(:delete).with(uri).never
+          confirm_and_execute
+        end
+
+        it "outputs waits for user to press a key to continue" do
+          confirm_and_execute
+          expect_output <<-PROMPT.strip_heredoc
+
+            Running Database dump to /tmp/my_db.dump...
+
+            Database dump failed. Check the logs for more information
+
+            Press any key to continue.
+          PROMPT
+        end
+
+        context "without a delete agreement" do
+          before do
+            subject.instance_variable_set(:@delete_agree, false)
+          end
+
+          it "does not delete the dump file" do
+            expect(File).to receive(:delete).with(uri).never
+            confirm_and_execute
+          end
+
+          it "outputs waits for user to press a key to continue" do
+            confirm_and_execute
+            expect_output <<-PROMPT.strip_heredoc
+
+              Running Database dump to /tmp/my_db.dump...
+
+              Database dump failed. Check the logs for more information
+
+              Press any key to continue.
+            PROMPT
+          end
+        end
+      end
+    end
+  end
 end
 # rubocop:enable Layout/TrailingWhitespace

--- a/spec/database_admin_spec.rb
+++ b/spec/database_admin_spec.rb
@@ -822,11 +822,37 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
     subject { described_class.new(:dump, input, output) }
 
     describe "#ask_questions" do
-      it "asks for file location" do
+      let(:pg_dump_warning) do
+        <<-WARN.strip_heredoc
+          WARNING:  This is not the recommended and supported way of running a
+          database backup, and is strictly meant for exporting a database for
+          support/debugging purposes!
+
+
+        WARN
+      end
+
+      it "warns about using pg_dump and asks for file location" do
         expect(subject).to receive(:say).with("Create Database Dump\n\n")
+        expect(subject).to receive(:say).with(pg_dump_warning)
         expect(subject).to receive(:ask_file_location)
 
         subject.ask_questions
+      end
+
+      it "has proper formatting for the pg_dump warning" do
+        allow(subject).to receive(:ask_file_location)
+        subject.ask_questions
+
+        expect_output <<-PROMPT.strip_heredoc
+          Create Database Dump
+
+          WARNING:  This is not the recommended and supported way of running a
+          database backup, and is strictly meant for exporting a database for
+          support/debugging purposes!
+
+
+        PROMPT
       end
     end
 


### PR DESCRIPTION
This continues to built off of #42 and #44, and adds new functionality to trigger `evm:db:dump:local` and `evm:db:dump:remote`, again with identical options for file location as restore (Local file, NFS, and SMB).

A slight change up from #44 is that this also adds in a warning for the "Dump" action, since it is not recommended/support to use `pg_dump` for database backups.  To ensure that users are aware of the difference, we are printing a warning when ever this action is executed.  Besides that, it behaves almost identically to "Backup" at the moment.


Links
-----

* Partially addresses https://bugzilla.redhat.com/show_bug.cgi?id=1535345
* Relies on https://github.com/ManageIQ/manageiq/pull/17483 being merged
* Diff specific to the changes between this PR and #44:  [diff](https://github.com/NickLaMuro/manageiq-appliance_console/compare/rfe-db-dump-from-appliance-console-menu-part-2...rfe-db-dump-from-appliance-console-menu-part-3)