### PR TITLE
Allow specifying table exclusions in Database Dump action

### DIFF
--- a/lib/manageiq/appliance_console/database_admin.rb
+++ b/lib/manageiq/appliance_console/database_admin.rb
@@ -39,6 +39,7 @@ module ManageIQ
         setting_header
         say(DB_DUMP_WARNING) if action == :dump
         ask_file_location
+        ask_for_tables_to_exclude_in_dump
       end
 
       def activate

--- a/lib/manageiq/appliance_console/database_admin.rb
+++ b/lib/manageiq/appliance_console/database_admin.rb
@@ -96,6 +96,26 @@ module ManageIQ
         end
       end
 
+      def ask_for_tables_to_exclude_in_dump
+        if action == :dump && should_exclude_tables?
+          say(<<-PROMPT.strip_heredoc)
+
+            To exclude tables from the dump, enter them in a space separated
+            list.  For example:
+
+                > metrics_* vim_performance_states event_streams
+
+          PROMPT
+          table_excludes = ask_for_many("table",
+                                        "tables to exclude",
+                                        "metrics_* vim_performance_states event_streams",
+                                        255,
+                                        Float::INFINITY)
+
+          @task_params.last[:"exclude-table-data"] = table_excludes
+        end
+      end
+
       def confirm_and_execute
         if allowed_to_execute?
           processing_message
@@ -124,6 +144,12 @@ module ManageIQ
       end
 
       private
+
+      def should_exclude_tables?
+        ask_yn?("Would you like to exclude tables in the dump") do |q|
+          q.readline = true
+        end
+      end
 
       def local_file_prompt
         if action == :restore

--- a/lib/manageiq/appliance_console/prompts.rb
+++ b/lib/manageiq/appliance_console/prompts.rb
@@ -63,6 +63,7 @@ module ApplianceConsole
         q.default = default if default
         q.validate = ->(p) { (p.blank? && default) || %w(y n).include?(p.downcase[0]) }
         q.responses[:not_valid] = "Please provide yes or no."
+        yield q if block_given?
       end.downcase[0] == 'y'
     end
 

--- a/spec/database_admin_spec.rb
+++ b/spec/database_admin_spec.rb
@@ -26,6 +26,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       it "asks for file location" do
         expect(subject).to receive(:say).with("Restore Database From Backup\n\n")
         expect(subject).to receive(:ask_file_location)
+        expect(subject).to receive(:ask_for_tables_to_exclude_in_dump)
 
         subject.ask_questions
       end
@@ -468,6 +469,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       it "asks for file location" do
         expect(subject).to receive(:say).with("Create Database Backup\n\n")
         expect(subject).to receive(:ask_file_location)
+        expect(subject).to receive(:ask_for_tables_to_exclude_in_dump)
 
         subject.ask_questions
       end
@@ -875,12 +877,14 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         expect(subject).to receive(:say).with("Create Database Dump\n\n")
         expect(subject).to receive(:say).with(pg_dump_warning)
         expect(subject).to receive(:ask_file_location)
+        expect(subject).to receive(:ask_for_tables_to_exclude_in_dump)
 
         subject.ask_questions
       end
 
       it "has proper formatting for the pg_dump warning" do
         allow(subject).to receive(:ask_file_location)
+        allow(subject).to receive(:ask_for_tables_to_exclude_in_dump)
         subject.ask_questions
 
         expect_output <<-PROMPT.strip_heredoc


### PR DESCRIPTION
This pull request exposes the functionality of the `--exclude-table-data` flag in `pg_dump`, which was added to `manageiq` and `manageiq-gems-pending` in the following pull requests respectively:

* https://github.com/ManageIQ/manageiq/pull/17483
* https://github.com/ManageIQ/manageiq-gems-pending/pull/351

In the user experience would look something like this:

```
Would you like to exclude tables in the dump? (Y/N): y
To exclude tables from the dump, enter them in a space separated
list.  For example:

    > metrics_* vim_performance_states event_streams

Enter the tables to exclude: |metrics_* vim_performance_states event_streams| event_streams
```


Links
-----

* Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1586186
* https://github.com/ManageIQ/manageiq/pull/17483
* https://github.com/ManageIQ/manageiq-gems-pending/pull/351