### PR TITLE
Add support to Enable OpenID-Connect in the appliance console.

### DIFF
--- a/lib/manageiq/appliance_console/external_auth_options.rb
+++ b/lib/manageiq/appliance_console/external_auth_options.rb
@@ -92,11 +92,11 @@ module ApplianceConsole
       end
 
       if params.include?("/authentication/saml_enabled=true")
-        params = remove_oidc(params)
+        remove_oidc(params)
       elsif params.include?("/authentication/oidc_enabled=true")
-        params = remove_saml(params)
+        remove_saml(params)
       elsif params.include?("/authentication/oidc_enabled=false") || params.include?("/authentication/saml_enabled=false")
-        params = provider_type_none(params)
+        provider_type_none(params)
       end
     end
 

--- a/lib/manageiq/appliance_console/external_auth_options.rb
+++ b/lib/manageiq/appliance_console/external_auth_options.rb
@@ -81,7 +81,7 @@ module ApplianceConsole
       if update_hash.present?
         say("\nUpdating external authentication options on appliance ...")
         params = update_hash.collect { |key, value| "#{key}=#{value}" }
-        params = enable_provider_type!(params)
+        params = configure_provider_type!(params)
         result = ManageIQ::ApplianceConsole::Utilities.rake_run("evm:settings:set", params)
         raise parse_errors(result).join(', ') if result.failure?
       end
@@ -93,27 +93,27 @@ module ApplianceConsole
       false
     end
 
-    def enable_provider_type!(params)
+    def configure_provider_type!(params)
       if params.include?("/authentication/saml_enabled=true")
-        provider_type_saml(params)
+        configure_saml!(params)
       elsif params.include?("/authentication/oidc_enabled=true")
-        provider_type_oidc(params)
+        configure_oidc!(params)
       elsif params.include?("/authentication/oidc_enabled=false") || params.include?("/authentication/saml_enabled=false")
-        provider_type_none(params)
+        configure_none!(params)
       end
     end
 
-    def provider_type_saml(params)
+    def configure_saml!(params)
       params << "/authentication/oidc_enabled=false"
       params << "/authentication/provider_type=saml"
     end
 
-    def provider_type_oidc(params)
+    def configure_oidc!(params)
       params << "/authentication/saml_enabled=false"
       params << "/authentication/provider_type=oidc"
     end
 
-    def provider_type_none(params)
+    def configure_none!(params)
       params << "/authentication/oidc_enabled=false"
       params << "/authentication/saml_enabled=false"
       params << "/authentication/provider_type=none"

--- a/lib/manageiq/appliance_console/external_auth_options.rb
+++ b/lib/manageiq/appliance_console/external_auth_options.rb
@@ -81,7 +81,7 @@ module ApplianceConsole
       if update_hash.present?
         say("\nUpdating external authentication options on appliance ...")
         params = update_hash.collect { |key, value| "#{key}=#{value}" }
-        params = enable_provider_type(params)
+        params = enable_provider_type!(params)
         result = ManageIQ::ApplianceConsole::Utilities.rake_run("evm:settings:set", params)
         raise parse_errors(result).join(', ') if result.failure?
       end
@@ -93,7 +93,7 @@ module ApplianceConsole
       false
     end
 
-    def enable_provider_type(params)
+    def enable_provider_type!(params)
       if params.include?("/authentication/saml_enabled=true")
         provider_type_saml(params)
       elsif params.include?("/authentication/oidc_enabled=true")

--- a/lib/manageiq/appliance_console/external_auth_options.rb
+++ b/lib/manageiq/appliance_console/external_auth_options.rb
@@ -87,27 +87,40 @@ module ApplianceConsole
     end
 
     def never_enable_saml_and_oidc(params)
-      if (params.include? "/authentication/oidc_enabled=true") && (params.include? "/authentication/saml_enabled=true")
+      if params.include?("/authentication/oidc_enabled=true") && params.include?("/authentication/saml_enabled=true")
         say("\nWARNING: Both SAML and OIDC can not be enable. SAML will be enabled ...")
       end
 
-      if params.include? "/authentication/saml_enabled=true"
-        params.grep(/.*oidc.*\z/).each { |p| params.delete(p) }
-        params << "/authentication/oidc_enabled=false"
-        params << "/authentication/provider_type=saml"
-      elsif params.include? "/authentication/oidc_enabled=true"
-        params.grep(/.*saml.*\z/).each { |p| params.delete(p) }
-        params << "/authentication/saml_enabled=false"
-        params << "/authentication/provider_type=oidc"
-      elsif (params.include? "/authentication/oidc_enabled=false") || (params.include? "/authentication/saml_enabled=false")
-        params.grep(/.*oidc.*\z/).each { |p| params.delete(p) }
-        params.grep(/.*saml.*\z/).each { |p| params.delete(p) }
-        params << "/authentication/oidc_enabled=false"
-        params << "/authentication/saml_enabled=false"
-        params << "/authentication/provider_type=none"
+      if params.include?("/authentication/saml_enabled=true")
+        params = remove_oidc(params)
+      elsif params.include?("/authentication/oidc_enabled=true")
+        params = remove_saml(params)
+      elsif params.include?("/authentication/oidc_enabled=false") || params.include?("/authentication/saml_enabled=false")
+        params = provider_type_none(params)
       end
+    end
 
-      params
+    def remove_oidc(params)
+      params.grep(/.*oidc.*\z/).each { |p| params.delete(p) }
+      params.grep(/.*provider_type.*\z/).each { |p| params.delete(p) }
+      params << "/authentication/oidc_enabled=false"
+      params << "/authentication/provider_type=saml"
+    end
+
+    def remove_saml(params)
+      params.grep(/.*saml.*\z/).each { |p| params.delete(p) }
+      params.grep(/.*provider_type.*\z/).each { |p| params.delete(p) }
+      params << "/authentication/saml_enabled=false"
+      params << "/authentication/provider_type=oidc"
+    end
+
+    def provider_type_none(params)
+      params.grep(/.*oidc.*\z/).each { |p| params.delete(p) }
+      params.grep(/.*saml.*\z/).each { |p| params.delete(p) }
+      params.grep(/.*provider_type.*\z/).each { |p| params.delete(p) }
+      params << "/authentication/oidc_enabled=false"
+      params << "/authentication/saml_enabled=false"
+      params << "/authentication/provider_type=none"
     end
 
     # extauth_opts option parser: syntax is key=value,key=value

--- a/lib/manageiq/appliance_console/external_auth_options.rb
+++ b/lib/manageiq/appliance_console/external_auth_options.rb
@@ -89,7 +89,7 @@ module ApplianceConsole
 
     def validate_provider_type
       return true unless @updates["/authentication/oidc_enabled"] == true && @updates["/authentication/saml_enabled"] == true
-      say("\Error: Both SAML and OIDC can not be enable ...")
+      say("\Error: Both SAML and OIDC can not be enabled ...")
       false
     end
 


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1610127/stories/121849185
https://www.pivotaltracker.com/n/projects/1610127/stories/121849185

The change introduced by this PR will allow the appliance console support of the OpenID Connect protocol.

This is a WIP PR for now as we only support OpenID in the pods now with the configmap generator. Standalone appliance apache config does not support OpenID (i.e. we don't have the separate Apache templates & the needed manual steps in http://manageiq.org/docs/reference/ under Authentication).


The change introduced by this PR is reliant on the following work for full OpenID Connect support:

[#16495](https://github.com/ManageIQ/manageiq/pull/16495)
ManageIQ/manageiq-ui-classic#2855
