### PR TITLE
Upgrade to repmgr version 4

### DIFF
--- a/lib/manageiq/appliance_console/database_replication.rb
+++ b/lib/manageiq/appliance_console/database_replication.rb
@@ -11,7 +11,7 @@ module ApplianceConsole
     PGPASS_FILE       = '/var/lib/pgsql/.pgpass'.freeze
     NETWORK_INTERFACE = 'eth0'.freeze
 
-    attr_accessor :cluster_name, :node_number, :database_name, :database_user,
+    attr_accessor :node_number, :database_name, :database_user,
                   :database_password, :primary_host
 
     def ask_for_unique_cluster_node_number
@@ -53,7 +53,6 @@ Replication Server Configuration
 
     def config_file_contents(host)
       <<-EOS.strip_heredoc
-        cluster=#{cluster_name}
         node=#{node_number}
         node_name=#{host}
         conninfo='host=#{host} user=#{database_user} dbname=#{database_name}'
@@ -64,20 +63,6 @@ Replication Server Configuration
         follow_command='repmgr standby follow'
         logfile=#{REPMGR_LOG}
       EOS
-    end
-
-    def generate_cluster_name
-      begin
-        pg_conn = PG::Connection.new(primary_connection_hash)
-        primary_region_number =
-          pg_conn.exec("SELECT last_value FROM miq_databases_id_seq").first["last_value"].to_i / 1_000_000_000_000
-        self.cluster_name = "miq_region_#{primary_region_number}_cluster"
-      rescue PG::ConnectionBad, PG::UndefinedTable => e
-        say("Failed to get primary region number #{e.message}")
-        logger.error("Failed to get primary region number #{e.message}")
-        return false
-      end
-      true
     end
 
     def write_pgpass_file

--- a/lib/manageiq/appliance_console/database_replication_primary.rb
+++ b/lib/manageiq/appliance_console/database_replication_primary.rb
@@ -30,27 +30,8 @@ module ApplianceConsole
     def activate
       say("Configuring Primary Replication Server...")
       create_config_file(primary_host) &&
-        initialize_primary_server &&
+        run_repmgr_command(REGISTER_CMD) &&
         write_pgpass_file
-    end
-
-    def initialize_primary_server
-      run_repmgr_command(REGISTER_CMD) &&
-        add_repmgr_schema_to_search_path
-    end
-
-    def add_repmgr_schema_to_search_path
-      schema_name = "repmgr"
-      begin
-        pg_conn = PG::Connection.new(primary_connection_hash)
-        new_path = pg_conn.exec("SHOW search_path").first["search_path"].split(",") << schema_name
-        pg_conn.exec("ALTER ROLE #{database_user} SET search_path = #{new_path.join(",")}")
-      rescue PG::ConnectionBad => e
-        say("Failed to add #{schema_name} to search path for #{database_user} #{e.message}")
-        logger.error("Failed to add #{schema_name} to search path for #{database_user} #{e.message}")
-        return false
-      end
-      true
     end
   end # class DatabaseReplicationPrimary < DatabaseReplication
 end # module ApplianceConsole

--- a/lib/manageiq/appliance_console/database_replication_primary.rb
+++ b/lib/manageiq/appliance_console/database_replication_primary.rb
@@ -3,7 +3,7 @@ module ApplianceConsole
   class DatabaseReplicationPrimary < DatabaseReplication
     include ManageIQ::ApplianceConsole::Logging
 
-    REGISTER_CMD = 'repmgr master register'.freeze
+    REGISTER_CMD = 'repmgr primary register'.freeze
 
     def initialize
       self.node_number       = nil

--- a/lib/manageiq/appliance_console/database_replication_primary.rb
+++ b/lib/manageiq/appliance_console/database_replication_primary.rb
@@ -6,7 +6,6 @@ module ApplianceConsole
     REGISTER_CMD = 'repmgr master register'.freeze
 
     def initialize
-      self.cluster_name      = nil
       self.node_number       = nil
       self.database_name     = "vmdb_production"
       self.database_user     = "root"
@@ -30,8 +29,7 @@ module ApplianceConsole
 
     def activate
       say("Configuring Primary Replication Server...")
-      generate_cluster_name &&
-        create_config_file(primary_host) &&
+      create_config_file(primary_host) &&
         initialize_primary_server &&
         write_pgpass_file
     end
@@ -42,7 +40,7 @@ module ApplianceConsole
     end
 
     def add_repmgr_schema_to_search_path
-      schema_name = "repmgr_#{cluster_name}"
+      schema_name = "repmgr"
       begin
         pg_conn = PG::Connection.new(primary_connection_hash)
         new_path = pg_conn.exec("SHOW search_path").first["search_path"].split(",") << schema_name

--- a/lib/manageiq/appliance_console/database_replication_standby.rb
+++ b/lib/manageiq/appliance_console/database_replication_standby.rb
@@ -64,10 +64,10 @@ module ApplianceConsole
       PostgresAdmin.prep_data_directory if disk || resync_data
       save_database_yml
       create_config_file(standby_host) &&
+        write_pgpass_file &&
         clone_standby_server &&
         start_postgres &&
         register_standby_server &&
-        write_pgpass_file &&
         (run_repmgrd_configuration ? start_repmgrd : true)
     end
 

--- a/lib/manageiq/appliance_console/database_replication_standby.rb
+++ b/lib/manageiq/appliance_console/database_replication_standby.rb
@@ -150,7 +150,7 @@ module ApplianceConsole
       c = PG::Connection.new(primary_connection_hash)
       c.exec_params(<<-SQL, [node_number]).map_types!(PG::BasicTypeMapForResults.new(c)).first
         SELECT type, name, active
-        FROM repl_nodes where id = $1
+        FROM repmgr.nodes where id = $1
       SQL
     end
 

--- a/lib/manageiq/appliance_console/database_replication_standby.rb
+++ b/lib/manageiq/appliance_console/database_replication_standby.rb
@@ -106,7 +106,7 @@ module ApplianceConsole
     end
 
     def register_standby_server
-      run_repmgr_command(REGISTER_CMD, :force => nil)
+      run_repmgr_command(REGISTER_CMD, :force => nil, :wait_sync= => 60)
     end
 
     def start_repmgrd

--- a/lib/manageiq/appliance_console/database_replication_standby.rb
+++ b/lib/manageiq/appliance_console/database_replication_standby.rb
@@ -130,7 +130,7 @@ module ApplianceConsole
       return true if rec.nil?
       node_state = rec["active"] ? "active" : "inactive"
 
-      say("An #{node_state} #{rec["type"]} node (#{rec["name"]}) with the node number #{node_number} already exists")
+      say("An #{node_state} #{rec["type"]} node (#{rec["node_name"]}) with the node number #{node_number} already exists")
       ask_yn?("Would you like to continue configuration by overwriting the existing node", "N")
 
     rescue PG::Error => e
@@ -149,8 +149,8 @@ module ApplianceConsole
     def record_for_node_number
       c = PG::Connection.new(primary_connection_hash)
       c.exec_params(<<-SQL, [node_number]).map_types!(PG::BasicTypeMapForResults.new(c)).first
-        SELECT type, name, active
-        FROM repmgr.nodes where id = $1
+        SELECT type, node_name, active
+        FROM repmgr.nodes where node_id = $1
       SQL
     end
 

--- a/lib/manageiq/appliance_console/database_replication_standby.rb
+++ b/lib/manageiq/appliance_console/database_replication_standby.rb
@@ -13,7 +13,6 @@ module ApplianceConsole
     attr_accessor :disk, :standby_host, :run_repmgrd_configuration, :resync_data, :force_register
 
     def initialize
-      self.cluster_name      = nil
       self.node_number       = nil
       self.database_name     = "vmdb_production"
       self.database_user     = "root"
@@ -64,8 +63,7 @@ module ApplianceConsole
       initialize_postgresql_disk if disk
       PostgresAdmin.prep_data_directory if disk || resync_data
       save_database_yml
-      generate_cluster_name &&
-        create_config_file(standby_host) &&
+      create_config_file(standby_host) &&
         clone_standby_server &&
         start_postgres &&
         register_standby_server &&

--- a/spec/database_replication_primary_spec.rb
+++ b/spec/database_replication_primary_spec.rb
@@ -56,60 +56,9 @@ describe ManageIQ::ApplianceConsole::DatabaseReplicationPrimary do
   context "#activate" do
     it "returns true when configure succeed" do
       expect(subject).to receive(:create_config_file).and_return(true)
-      expect(subject).to receive(:initialize_primary_server).and_return(true)
+      expect(subject).to receive(:run_repmgr_command).with("repmgr primary register").and_return(true)
       expect(subject).to receive(:write_pgpass_file).and_return(true)
       expect(subject.activate).to be true
-    end
-  end
-
-  context "#initialize_primary_server" do
-    before do
-      allow(Process::UID).to receive(:change_privilege)
-      allow(Process::UID).to receive(:from_name)
-
-      expect(subject).to receive(:fork) do |&block|
-        block.call
-        1234 # return a test pid
-      end
-    end
-
-    it "raises an error when REGISTER_CMD fails" do
-      result = double(SPEC_NAME, :output => '', :error => '')
-      allow(AwesomeSpawn).to receive(:run!).and_raise(AwesomeSpawn::CommandResultError.new('', result))
-      expect { subject.initialize_primary_server }.to raise_error(AwesomeSpawn::CommandResultError)
-    end
-
-    it "Adds the schema to the search path when REGISTER_CMD succeeds" do
-      expect(Process).to receive(:wait).with(1234)
-      stub_const("ManageIQ::ApplianceConsole::DatabaseReplicationPrimary::REGISTER_CMD", "pwd")
-      expect(subject).to receive(:add_repmgr_schema_to_search_path).and_return(true)
-      expect(subject.initialize_primary_server).to be true
-    end
-  end
-
-  describe "#add_repmgr_schema_to_search_path" do
-    let(:db_user)      { "test_db_user" }
-    let(:schema_name)  { "repmgr_#{cluster_name}" }
-
-    before do
-      subject.database_user = db_user
-    end
-
-    it "adds the new schema to the search path" do
-      orig_path = "\"$user\",public"
-      new_path  = "\"$user\",public,#{schema_name}"
-
-      connection = double(SPEC_NAME)
-      expect(PG::Connection).to receive(:new).and_return(connection)
-      expect(connection).to receive(:exec).with("SHOW search_path").and_return([{"search_path" => orig_path}])
-      expect(connection).to receive(:exec).with("ALTER ROLE #{db_user} SET search_path = #{new_path}")
-
-      expect(subject.add_repmgr_schema_to_search_path).to be true
-    end
-
-    it "returns false if the connection fails" do
-      expect(PG::Connection).to receive(:new).and_raise(PG::ConnectionBad)
-      expect(subject.add_repmgr_schema_to_search_path).to be false
     end
   end
 end

--- a/spec/database_replication_primary_spec.rb
+++ b/spec/database_replication_primary_spec.rb
@@ -55,7 +55,6 @@ describe ManageIQ::ApplianceConsole::DatabaseReplicationPrimary do
 
   context "#activate" do
     it "returns true when configure succeed" do
-      expect(subject).to receive(:generate_cluster_name).and_return(true)
       expect(subject).to receive(:create_config_file).and_return(true)
       expect(subject).to receive(:initialize_primary_server).and_return(true)
       expect(subject).to receive(:write_pgpass_file).and_return(true)
@@ -89,12 +88,10 @@ describe ManageIQ::ApplianceConsole::DatabaseReplicationPrimary do
   end
 
   describe "#add_repmgr_schema_to_search_path" do
-    let(:cluster_name) { "test_cluster" }
     let(:db_user)      { "test_db_user" }
     let(:schema_name)  { "repmgr_#{cluster_name}" }
 
     before do
-      subject.cluster_name = cluster_name
       subject.database_user = db_user
     end
 

--- a/spec/database_replication_spec.rb
+++ b/spec/database_replication_spec.rb
@@ -61,7 +61,6 @@ describe ManageIQ::ApplianceConsole::DatabaseReplication do
   context "#config_file_contents" do
     let(:expected_config_file) do
       <<-EOS.strip_heredoc
-        cluster=clustername
         node=nodenumber
         node_name=host
         conninfo='host=host user=user dbname=databasename'
@@ -75,28 +74,11 @@ describe ManageIQ::ApplianceConsole::DatabaseReplication do
     end
 
     it "returns the correct contents" do
-      subject.cluster_name      = "clustername"
       subject.node_number       = "nodenumber"
       subject.database_name     = "databasename"
       subject.database_user     = "user"
 
       expect(subject.config_file_contents("host")).to eq(expected_config_file)
-    end
-  end
-
-  context "#generate_cluster_name" do
-    it "should generate a cluster name and return true" do
-      expect(PG::Connection)
-        .to receive(:new)
-        .and_return(double(SPEC_NAME, :exec => double(SPEC_NAME, :first => { "last_value" => "1_000_000_000_001" })))
-      expect(subject.generate_cluster_name).to be_truthy
-      expect(subject.cluster_name).to eq("miq_region_1_cluster")
-    end
-
-    it "should log an error on connection failures and return false" do
-      expect(PG::Connection).to receive(:new).and_raise(PG::ConnectionBad)
-      expect(subject).to receive(:say).with(/^failed/i)
-      expect(subject.generate_cluster_name).to be_falsey
     end
   end
 

--- a/spec/database_replication_spec.rb
+++ b/spec/database_replication_spec.rb
@@ -61,16 +61,31 @@ describe ManageIQ::ApplianceConsole::DatabaseReplication do
   context "#config_file_contents" do
     let(:expected_config_file) do
       <<-EOS.strip_heredoc
-        node=nodenumber
+        node_id=nodenumber
         node_name=host
         conninfo='host=host user=user dbname=databasename'
         use_replication_slots=1
         pg_basebackup_options='--xlog-method=stream'
         failover=automatic
-        promote_command='repmgr standby promote'
-        follow_command='repmgr standby follow'
-        logfile=/var/log/repmgr/repmgrd.log
+        promote_command='repmgr standby promote -f /etc/repmgr.conf --log-to-file'
+        follow_command='repmgr standby follow -f /etc/repmgr.conf --log-to-file --upstream-node-id=%n'
+        log_file=/var/log/repmgr/repmgrd.log
+        service_start_command='sudo systemctl start postgresql-9.5'
+        service_stop_command='sudo systemctl stop postgresql-9.5'
+        service_restart_command='sudo systemctl restart postgresql-9.5'
+        service_reload_command='sudo systemctl reload postgresql-9.5'
+        data_directory='/var/lib/pgsql'
       EOS
+    end
+
+    before do
+      ENV["APPLIANCE_PG_DATA"] = "/var/lib/pgsql"
+      ENV["APPLIANCE_PG_SERVICE"] = "postgresql-9.5"
+    end
+
+    after do
+      ENV.delete("APPLIANCE_PG_DATA")
+      ENV.delete("APPLIANCE_PG_SERVICE")
     end
 
     it "returns the correct contents" do

--- a/spec/database_replication_standby_spec.rb
+++ b/spec/database_replication_standby_spec.rb
@@ -186,7 +186,7 @@ describe ManageIQ::ApplianceConsole::DatabaseReplicationStandby do
         run_args = [
           "repmgr standby register",
           {
-            :params => {:force => nil},
+            :params => {:force => nil, :wait_sync= => 60},
             :env    => {"PGPASSWORD" => "secret"}
           }
         ]

--- a/spec/database_replication_standby_spec.rb
+++ b/spec/database_replication_standby_spec.rb
@@ -112,7 +112,6 @@ describe ManageIQ::ApplianceConsole::DatabaseReplicationStandby do
       expect(subject).to receive(:stop_postgres)
       expect(subject).to receive(:stop_repmgrd)
       expect(subject).to receive(:save_database_yml)
-      expect(subject).to receive(:generate_cluster_name).and_return(true)
       expect(subject).to receive(:create_config_file).and_return(true)
       expect(subject).to receive(:clone_standby_server).and_return(true)
       expect(subject).to receive(:start_postgres).and_return(true)


### PR DESCRIPTION
This PR makes all the necessary changes to be compatible with the newest major version of [repmgr](https://repmgr.org/docs/4.0/index.html)

In particular this PR does the following:

- Removes the cluster name and associated logic (this is no longer used by repmgr)
- Renames the config file keys
- Alters the primary registration command from `master` to `primary`
- Removes the logic around adding the schema to the search path
- Slightly alters the `promote` and `follow` commands
- Adds configuration to use `systemctl` to alter the state of the postgres cluster

The upgrade in combination with some enhancements here will solve the following bus and tracking issues:
https://bugzilla.redhat.com/show_bug.cgi?id=1418080
https://www.pivotaltracker.com/story/show/135779733
https://www.pivotaltracker.com/story/show/141523501