### PR TITLE
Adds file splitting support to dump/backup commands

### DIFF
--- a/lib/manageiq/appliance_console/database_admin.rb
+++ b/lib/manageiq/appliance_console/database_admin.rb
@@ -42,6 +42,7 @@ module ManageIQ
         say(DB_DUMP_WARNING) if action == :dump
         ask_file_location
         ask_for_tables_to_exclude_in_dump
+        ask_to_split_up_output
       end
 
       def activate

--- a/lib/manageiq/appliance_console/database_admin.rb
+++ b/lib/manageiq/appliance_console/database_admin.rb
@@ -147,6 +147,12 @@ module ManageIQ
         end || true
       end
 
+      def ask_to_split_up_output
+        if action == :dump && should_split_output?
+          @task_params.last[:byte_count] = ask_for_string("byte size to split by", "500M")
+        end || true
+      end
+
       def confirm_and_execute
         if allowed_to_execute?
           processing_message
@@ -178,6 +184,12 @@ module ManageIQ
 
       def should_exclude_tables?
         ask_yn?("Would you like to exclude tables in the dump") do |q|
+          q.readline = true
+        end
+      end
+
+      def should_split_output?
+        ask_yn?("Would you like to split the #{action} output into multiple parts") do |q|
           q.readline = true
         end
       end

--- a/spec/database_admin_spec.rb
+++ b/spec/database_admin_spec.rb
@@ -27,6 +27,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         expect(subject).to receive(:say).with("Restore Database From Backup\n\n")
         expect(subject).to receive(:ask_file_location)
         expect(subject).to receive(:ask_for_tables_to_exclude_in_dump)
+        expect(subject).to receive(:ask_to_split_up_output)
 
         subject.ask_questions
       end
@@ -613,6 +614,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         expect(subject).to receive(:say).with("Create Database Backup\n\n")
         expect(subject).to receive(:ask_file_location)
         expect(subject).to receive(:ask_for_tables_to_exclude_in_dump)
+        expect(subject).to receive(:ask_to_split_up_output)
 
         subject.ask_questions
       end
@@ -1172,6 +1174,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         expect(subject).to receive(:say).with(pg_dump_warning)
         expect(subject).to receive(:ask_file_location)
         expect(subject).to receive(:ask_for_tables_to_exclude_in_dump)
+        expect(subject).to receive(:ask_to_split_up_output)
 
         subject.ask_questions
       end
@@ -1179,6 +1182,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       it "has proper formatting for the pg_dump warning" do
         allow(subject).to receive(:ask_file_location)
         allow(subject).to receive(:ask_for_tables_to_exclude_in_dump)
+        allow(subject).to receive(:ask_to_split_up_output)
         subject.ask_questions
 
         expect_output <<-PROMPT.strip_heredoc

--- a/spec/database_admin_spec.rb
+++ b/spec/database_admin_spec.rb
@@ -449,6 +449,27 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       end
     end
 
+    describe "#ask_to_split_up_output" do
+      let(:uri)               { "/tmp/my_db.dump" }
+      let(:yn_prompt)         { "Would you like to split the restore output into multiple parts" }
+      let(:byte_count_prompt) { "byte size to split by" }
+
+      before do
+        subject.instance_variable_set(:@task_params, ["--", { :uri => uri }])
+      end
+
+      it "no-ops" do
+        expect(subject).to receive(:ask_yn?).with(yn_prompt).never
+        expect(subject).to receive(:ask_for_string).with(byte_count_prompt, "500M").never
+        expect(subject.ask_to_split_up_output).to be_truthy
+      end
+
+      it "does not modify the @task_params" do
+        expect(subject.ask_to_split_up_output).to be_truthy
+        expect(subject.task_params).to eq(["--", {:uri => uri}])
+      end
+    end
+
     describe "#confirm_and_execute" do
       let(:uri)             { "/tmp/my_db.backup" }
       let(:agree)           { "y" }
@@ -1006,6 +1027,27 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       end
     end
 
+    describe "#ask_to_split_up_output" do
+      let(:uri)               { "/tmp/my_db.dump" }
+      let(:yn_prompt)         { "Would you like to split the restore output into multiple parts" }
+      let(:byte_count_prompt) { "byte size to split by" }
+
+      before do
+        subject.instance_variable_set(:@task_params, ["--", { :uri => uri }])
+      end
+
+      it "no-ops" do
+        expect(subject).to receive(:ask_yn?).with(yn_prompt).never
+        expect(subject).to receive(:ask_for_string).with(byte_count_prompt, "500M").never
+        expect(subject.ask_to_split_up_output).to be_truthy
+      end
+
+      it "does not modify the @task_params" do
+        expect(subject.ask_to_split_up_output).to be_truthy
+        expect(subject.task_params).to eq(["--", {:uri => uri}])
+      end
+    end
+
     describe "#confirm_and_execute" do
       let(:uri)             { "/tmp/my_db.backup" }
       let(:agree)           { "y" }
@@ -1453,6 +1495,55 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
 
           expect(subject.ask_for_tables_to_exclude_in_dump).to be_truthy
           expect(subject.task_params).to eq(["--", {:uri => uri, :"exclude-table-data" => ["metrics_*", "vim_performance_states", "event_streams"]}])
+        end
+      end
+    end
+
+    describe "#ask_to_split_up_output" do
+      let(:uri)               { "/tmp/my_db.dump" }
+      let(:yn_prompt)         { "Would you like to split the dump output into multiple parts" }
+      let(:byte_count_prompt) { "byte size to split by" }
+
+      before do
+        subject.instance_variable_set(:@task_params, ["--", { :uri => uri }])
+      end
+
+      context "when not splitting output" do
+        it "does not add :byte_count to @task_params" do
+          expect(subject).to receive(:ask_yn?).with(yn_prompt).once.and_call_original
+          expect(subject).to receive(:ask_for_string).with(byte_count_prompt, "500M").never
+
+          say "n"
+          expect(subject.ask_to_split_up_output).to be_truthy
+
+          expect(subject.task_params).to eq(["--", {:uri => uri}])
+        end
+      end
+
+      context "when splitting output" do
+        it "prompts the user" do
+          say ["y", "750M"]
+          expect(subject.ask_to_split_up_output).to be_truthy
+          expect_readline_question_asked <<-PROMPT.strip_heredoc.chomp
+            Would you like to split the dump output into multiple parts? (Y/N): y
+            Enter the byte size to split by: |500M| 750M
+          PROMPT
+        end
+
+        it "adds `:byte_count => '250M'` to @task_params" do
+          expect(subject).to receive(:ask_yn?).with(yn_prompt).once.and_call_original
+          expect(subject).to receive(:ask_for_string).with(byte_count_prompt, "500M").once.and_call_original
+          say ["y", "250M"]
+
+          expect(subject.ask_to_split_up_output).to be_truthy
+          expect(subject.task_params).to eq(["--", {:uri => uri, :byte_count => "250M"}])
+        end
+
+        it "defaults to '500M'" do
+          say ["y", ""]
+
+          expect(subject.ask_to_split_up_output).to be_truthy
+          expect(subject.task_params).to eq(["--", {:uri => uri, :byte_count => "500M"}])
         end
       end
     end


### PR DESCRIPTION
~~**NOTE:**  Currently built off of https://github.com/ManageIQ/manageiq-appliance_console/pull/51~~ **Update:**  This has been rebased and this branch updated accordingly.

This exposes the `:byte_count` flag that is added to the `evm:db:backup` and `evm:db:dump` tasks here:

* https://github.com/ManageIQ/manageiq/pull/17894

The user experience will look something like the following:

```
Would you like to split the dump output into multiple parts? (Y/N): y
Enter the byte size to split by: |500M| 750M
```


Links
-----

* Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1586176
* Relies on the following to be merged to function:
  - [x] https://github.com/ManageIQ/manageiq-gems-pending/pull/361
  - [x] https://github.com/ManageIQ/manageiq/pull/17894
  - [x] [ManageIQ/manageiq-appliance_console#51](https://github.com/ManageIQ/manageiq-appliance_console/pull/51)