### PR TITLE
Fixes to DatabaseAdmin commands

### DIFF
--- a/lib/manageiq/appliance_console/database_admin.rb
+++ b/lib/manageiq/appliance_console/database_admin.rb
@@ -61,11 +61,7 @@ module ManageIQ
       end
 
       def ask_local_file_options
-        validator = LOCAL_FILE_VALIDATOR if action == :restore
-        default   = action == :dump ? DB_DEFAULT_DUMP_FILE : DB_RESTORE_FILE
-
-        @uri = just_ask(local_file_prompt, default, validator, "file that exists")
-
+        @uri         = just_ask(*filename_prompt_args)
         @task        = "evm:db:#{action}:local"
         @task_params = ["--", {:local_file => uri}]
       end
@@ -152,6 +148,12 @@ module ManageIQ
         ask_yn?("Would you like to exclude tables in the dump") do |q|
           q.readline = true
         end
+      end
+
+      def filename_prompt_args
+        default   = action == :dump ? DB_DEFAULT_DUMP_FILE : DB_RESTORE_FILE
+        validator = LOCAL_FILE_VALIDATOR if action == :restore
+        [local_file_prompt, default, validator, "file that exists"]
       end
 
       def local_file_prompt

--- a/lib/manageiq/appliance_console/database_admin.rb
+++ b/lib/manageiq/appliance_console/database_admin.rb
@@ -78,19 +78,20 @@ module ManageIQ
       end
 
       def ask_smb_file_options
+        @filename    = just_ask(*filename_prompt_args) unless action == :restore
         @uri         = ask_for_uri(*remote_file_prompt_args_for("smb"))
         user         = just_ask(USER_PROMPT)
         pass         = ask_for_password("password for #{user}")
 
+        params = {
+          :uri          => uri,
+          :uri_username => user,
+          :uri_password => pass
+        }
+        params[:remote_file_name] = filename if filename
+
         @task        = "evm:db:#{action}:remote"
-        @task_params = [
-          "--",
-          {
-            :uri          => uri,
-            :uri_username => user,
-            :uri_password => pass
-          }
-        ]
+        @task_params = ["--", params]
       end
 
       def ask_to_delete_backup_after_restore

--- a/lib/manageiq/appliance_console/database_admin.rb
+++ b/lib/manageiq/appliance_console/database_admin.rb
@@ -116,7 +116,7 @@ module ManageIQ
                                         Float::INFINITY)
 
           @task_params.last[:"exclude-table-data"] = table_excludes
-        end
+        end || true
       end
 
       def confirm_and_execute

--- a/lib/manageiq/appliance_console/database_admin.rb
+++ b/lib/manageiq/appliance_console/database_admin.rb
@@ -27,7 +27,7 @@ module ManageIQ
 
       WARN
 
-      attr_reader :action, :backup_type, :task, :task_params, :delete_agree, :uri
+      attr_reader :action, :backup_type, :task, :task_params, :delete_agree, :uri, :filename
 
       def initialize(action = :restore, input = $stdin, output = $stdout)
         super(input, output)
@@ -67,9 +67,14 @@ module ManageIQ
       end
 
       def ask_nfs_file_options
+        @filename    = just_ask(*filename_prompt_args) unless action == :restore
         @uri         = ask_for_uri(*remote_file_prompt_args_for("nfs"))
         @task        = "evm:db:#{action}:remote"
-        @task_params = ["--", {:uri => uri}]
+
+        params = {:uri => uri}
+        params[:remote_file_name] = filename if filename
+
+        @task_params = ["--", params]
       end
 
       def ask_smb_file_options
@@ -152,7 +157,7 @@ module ManageIQ
 
       def filename_prompt_args
         default   = action == :dump ? DB_DEFAULT_DUMP_FILE : DB_RESTORE_FILE
-        validator = LOCAL_FILE_VALIDATOR if action == :restore
+        validator = LOCAL_FILE_VALIDATOR if action == :restore && backup_type == LOCAL_FILE
         [local_file_prompt, default, validator, "file that exists"]
       end
 

--- a/lib/manageiq/appliance_console/database_admin.rb
+++ b/lib/manageiq/appliance_console/database_admin.rb
@@ -60,8 +60,10 @@ module ManageIQ
       end
 
       def ask_local_file_options
+        validator = LOCAL_FILE_VALIDATOR if action == :restore
+
         @uri = just_ask(local_file_prompt,
-                        DB_RESTORE_FILE, LOCAL_FILE_VALIDATOR,
+                        DB_RESTORE_FILE, validator,
                         "file that exists")
 
         @task        = "evm:db:#{action}:local"

--- a/lib/manageiq/appliance_console/database_admin.rb
+++ b/lib/manageiq/appliance_console/database_admin.rb
@@ -11,6 +11,7 @@ module ManageIQ
       FILE_OPTIONS   = [LOCAL_FILE, NFS_FILE, SMB_FILE, CANCEL].freeze
 
       DB_RESTORE_FILE      = "/tmp/evm_db.backup".freeze
+      DB_DEFAULT_DUMP_FILE = "/tmp/evm_db.dump".freeze
       LOCAL_FILE_VALIDATOR = ->(a) { File.exist?(a) }.freeze
 
       USER_PROMPT = <<-PROMPT.strip_heredoc.chomp
@@ -61,10 +62,9 @@ module ManageIQ
 
       def ask_local_file_options
         validator = LOCAL_FILE_VALIDATOR if action == :restore
+        default   = action == :dump ? DB_DEFAULT_DUMP_FILE : DB_RESTORE_FILE
 
-        @uri = just_ask(local_file_prompt,
-                        DB_RESTORE_FILE, validator,
-                        "file that exists")
+        @uri = just_ask(local_file_prompt, default, validator, "file that exists")
 
         @task        = "evm:db:#{action}:local"
         @task_params = ["--", {:local_file => uri}]

--- a/spec/database_admin_spec.rb
+++ b/spec/database_admin_spec.rb
@@ -942,7 +942,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
     describe "#ask_local_file_options" do
       let(:filepath)  { "/file/that/most/certainly/does/not/exist.dump" }
       let(:prmpt)     { "location to save the dump file to" }
-      let(:default)   { described_class::DB_RESTORE_FILE }
+      let(:default)   { described_class::DB_DEFAULT_DUMP_FILE }
       let(:errmsg)    { "file that exists" }
 
       context "with no filename given" do

--- a/spec/database_admin_spec.rb
+++ b/spec/database_admin_spec.rb
@@ -538,17 +538,13 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
     end
 
     describe "#ask_local_file_options" do
-      let(:file)      { Tempfile.new("foo.backup").tap(&:close) }
+      let(:filepath)  { "/file/that/most/certainly/does/not/exist.dump" }
       let(:prmpt)     { "location to save the backup file to" }
       let(:default)   { described_class::DB_RESTORE_FILE }
       let(:errmsg)    { "file that exists" }
 
       context "with no filename given" do
         before do
-          # stub validator for default answer, since it probably doesn't exist on
-          # the machine running these tests.
-          stub_const("#{described_class.name}::LOCAL_FILE_VALIDATOR", ->(_) { true })
-
           say ""
           subject.ask_local_file_options
         end
@@ -560,12 +556,12 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
 
       context "with a valid filename given" do
         before do
-          say file.path.to_s
+          say filepath.to_s
           subject.ask_local_file_options
         end
 
         it "sets @uri to point to the local file" do
-          expect(subject.uri).to eq(file.path)
+          expect(subject.uri).to eq(filepath)
         end
 
         it "sets @task to point to 'evm:db:backup:local'" do
@@ -573,25 +569,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         end
 
         it "sets @task_params to point to the local file" do
-          expect(subject.task_params).to eq(["--", {:local_file => file.path}])
-        end
-      end
-
-      context "with an invalid filename given" do
-        let(:bad_filename) { "#{file.path}.bad_mmkay" }
-
-        before do
-          say [bad_filename, file.path.to_s]
-          subject.ask_local_file_options
-        end
-
-        it "reprompts the user and then properly sets the options" do
-          error = "Please provide #{errmsg}"
-          expect_heard ["Enter the #{prmpt}: ", error, prompt]
-
-          expect(subject.uri).to         eq(file.path)
-          expect(subject.task).to        eq("evm:db:backup:local")
-          expect(subject.task_params).to eq(["--", {:local_file => file.path}])
+          expect(subject.task_params).to eq(["--", {:local_file => filepath}])
         end
       end
     end
@@ -962,17 +940,13 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
     end
 
     describe "#ask_local_file_options" do
-      let(:file)      { Tempfile.new("foo.dump").tap(&:close) }
+      let(:filepath)  { "/file/that/most/certainly/does/not/exist.dump" }
       let(:prmpt)     { "location to save the dump file to" }
       let(:default)   { described_class::DB_RESTORE_FILE }
       let(:errmsg)    { "file that exists" }
 
       context "with no filename given" do
         before do
-          # stub validator for default answer, since it probably doesn't exist on
-          # the machine running these tests.
-          stub_const("#{described_class.name}::LOCAL_FILE_VALIDATOR", ->(_) { true })
-
           say ""
           subject.ask_local_file_options
         end
@@ -984,12 +958,12 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
 
       context "with a valid filename given" do
         before do
-          say file.path.to_s
+          say filepath
           subject.ask_local_file_options
         end
 
         it "sets @uri to point to the local file" do
-          expect(subject.uri).to eq(file.path)
+          expect(subject.uri).to eq(filepath)
         end
 
         it "sets @task to point to 'evm:db:dump:local'" do
@@ -997,25 +971,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         end
 
         it "sets @task_params to point to the local file" do
-          expect(subject.task_params).to eq(["--", {:local_file => file.path}])
-        end
-      end
-
-      context "with an invalid filename given" do
-        let(:bad_filename) { "#{file.path}.bad_mmkay" }
-
-        before do
-          say [bad_filename, file.path.to_s]
-          subject.ask_local_file_options
-        end
-
-        it "reprompts the user and then properly sets the options" do
-          error = "Please provide #{errmsg}"
-          expect_heard ["Enter the #{prmpt}: ", error, prompt]
-
-          expect(subject.uri).to         eq(file.path)
-          expect(subject.task).to        eq("evm:db:dump:local")
-          expect(subject.task_params).to eq(["--", {:local_file => file.path}])
+          expect(subject.task_params).to eq(["--", {:local_file => filepath}])
         end
       end
     end

--- a/spec/database_admin_spec.rb
+++ b/spec/database_admin_spec.rb
@@ -107,7 +107,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
           stub_const("#{described_class.name}::LOCAL_FILE_VALIDATOR", ->(_) { true })
 
           say ""
-          subject.ask_local_file_options
+          expect(subject.ask_local_file_options).to be_truthy
         end
 
         it "sets @uri to the default filename" do
@@ -118,7 +118,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       context "with a valid filename given" do
         before do
           say file.path.to_s
-          subject.ask_local_file_options
+          expect(subject.ask_local_file_options).to be_truthy
         end
 
         it "sets @uri to point to the local file" do
@@ -137,12 +137,10 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       context "with an invalid filename given" do
         let(:bad_filename) { "#{file.path}.bad_mmkay" }
 
-        before do
-          say [bad_filename, file.path.to_s]
-          subject.ask_local_file_options
-        end
-
         it "reprompts the user and then properly sets the options" do
+          say [bad_filename, file.path.to_s]
+          expect(subject.ask_local_file_options).to be_truthy
+
           error = "Please provide #{errmsg}"
           expect_heard ["Enter the #{prmpt}: ", error, prompt]
 
@@ -161,7 +159,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       context "with a valid uri given" do
         before do
           say example_uri
-          subject.ask_nfs_file_options
+          expect(subject.ask_nfs_file_options).to be_truthy
         end
 
         it "sets @uri to point to the nfs file" do
@@ -180,12 +178,10 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       context "with an invalid uri given" do
         let(:bad_uri) { "file://host.mydomain.com/path/to/file" }
 
-        before do
-          say [bad_uri, example_uri]
-          subject.ask_nfs_file_options
-        end
-
         it "reprompts the user and then properly sets the options" do
+          say [bad_uri, example_uri]
+          expect(subject.ask_nfs_file_options).to be_truthy
+
           error = "Please provide #{errmsg}"
           expect_heard ["Enter the #{prmpt}: ", error, prompt]
 
@@ -219,7 +215,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       context "with a valid uri, username, and password given" do
         before do
           say [example_uri, user, pass]
-          subject.ask_smb_file_options
+          expect(subject.ask_smb_file_options).to be_truthy
         end
 
         it "sets @uri to point to the smb file" do
@@ -240,7 +236,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
 
         before do
           say [bad_uri, example_uri, user, pass]
-          subject.ask_smb_file_options
+          expect(subject.ask_smb_file_options).to be_truthy
         end
 
         it "reprompts the user and then properly sets the options" do
@@ -318,11 +314,11 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       it "no-ops" do
         expect(subject).to receive(:ask_yn?).with("Would you like to exclude tables in the dump").never
         expect(subject).to receive(:ask_for_many).with("table", "tables to exclude", default_table_excludes, 255, Float::INFINITY).never
-        subject.ask_for_tables_to_exclude_in_dump
+        expect(subject.ask_for_tables_to_exclude_in_dump).to be_truthy
       end
 
       it "does not modify the @task_params" do
-        subject.ask_for_tables_to_exclude_in_dump
+        expect(subject.ask_for_tables_to_exclude_in_dump).to be_truthy
         expect(subject.task_params).to eq(["--", {:uri => uri}])
       end
     end
@@ -544,12 +540,9 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       let(:errmsg)    { "file that exists" }
 
       context "with no filename given" do
-        before do
-          say ""
-          subject.ask_local_file_options
-        end
-
         it "sets @uri to the default filename" do
+          say ""
+          expect(subject.ask_local_file_options).to be_truthy
           expect(subject.uri).to eq(default)
         end
       end
@@ -557,7 +550,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       context "with a valid filename given" do
         before do
           say filepath.to_s
-          subject.ask_local_file_options
+          expect(subject.ask_local_file_options).to be_truthy
         end
 
         it "sets @uri to point to the local file" do
@@ -582,7 +575,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       context "with a valid uri given" do
         before do
           say example_uri
-          subject.ask_nfs_file_options
+          expect(subject.ask_nfs_file_options).to be_truthy
         end
 
         it "sets @uri to point to the nfs file" do
@@ -603,7 +596,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
 
         before do
           say [bad_uri, example_uri]
-          subject.ask_nfs_file_options
+          expect(subject.ask_nfs_file_options).to be_truthy
         end
 
         it "reprompts the user and then properly sets the options" do
@@ -640,7 +633,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       context "with a valid uri, username, and password given" do
         before do
           say [example_uri, user, pass]
-          subject.ask_smb_file_options
+          expect(subject.ask_smb_file_options).to be_truthy
         end
 
         it "sets @uri to point to the smb file" do
@@ -661,7 +654,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
 
         before do
           say [bad_uri, example_uri, user, pass]
-          subject.ask_smb_file_options
+          expect(subject.ask_smb_file_options).to be_truthy
         end
 
         it "reprompts the user and then properly sets the options" do
@@ -723,11 +716,11 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       it "no-ops" do
         expect(subject).to receive(:ask_yn?).with("Would you like to exclude tables in the dump").never
         expect(subject).to receive(:ask_for_many).with("table", "tables to exclude", default_table_excludes, 255, Float::INFINITY).never
-        subject.ask_for_tables_to_exclude_in_dump
+        expect(subject.ask_for_tables_to_exclude_in_dump).to be_truthy
       end
 
       it "does not modify the @task_params" do
-        subject.ask_for_tables_to_exclude_in_dump
+        expect(subject.ask_for_tables_to_exclude_in_dump).to be_truthy
         expect(subject.task_params).to eq(["--", {:uri => uri}])
       end
     end
@@ -946,12 +939,9 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       let(:errmsg)    { "file that exists" }
 
       context "with no filename given" do
-        before do
-          say ""
-          subject.ask_local_file_options
-        end
-
         it "sets @uri to the default filename" do
+          say ""
+          expect(subject.ask_local_file_options).to be_truthy
           expect(subject.uri).to eq(default)
         end
       end
@@ -959,7 +949,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       context "with a valid filename given" do
         before do
           say filepath
-          subject.ask_local_file_options
+          expect(subject.ask_local_file_options).to be_truthy
         end
 
         it "sets @uri to point to the local file" do
@@ -984,7 +974,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       context "with a valid uri given" do
         before do
           say example_uri
-          subject.ask_nfs_file_options
+          expect(subject.ask_nfs_file_options).to be_truthy
         end
 
         it "sets @uri to point to the nfs file" do
@@ -1003,12 +993,10 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       context "with an invalid uri given" do
         let(:bad_uri) { "file://host.mydomain.com/path/to/file" }
 
-        before do
-          say [bad_uri, example_uri]
-          subject.ask_nfs_file_options
-        end
-
         it "reprompts the user and then properly sets the options" do
+          say [bad_uri, example_uri]
+          expect(subject.ask_nfs_file_options).to be_truthy
+
           error = "Please provide #{errmsg}"
           expect_heard ["Enter the #{prmpt}: ", error, prompt]
 
@@ -1042,7 +1030,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       context "with a valid uri, username, and password given" do
         before do
           say [example_uri, user, pass]
-          subject.ask_smb_file_options
+          expect(subject.ask_smb_file_options).to be_truthy
         end
 
         it "sets @uri to point to the smb file" do
@@ -1063,7 +1051,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
 
         before do
           say [bad_uri, example_uri, user, pass]
-          subject.ask_smb_file_options
+          expect(subject.ask_smb_file_options).to be_truthy
         end
 
         it "reprompts the user and then properly sets the options" do
@@ -1128,7 +1116,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
           expect(subject).to receive(:ask_for_many).with("table", "tables to exclude", default_table_excludes, 255, Float::INFINITY).never
 
           say "n"
-          subject.ask_for_tables_to_exclude_in_dump
+          expect(subject.ask_for_tables_to_exclude_in_dump).to be_truthy
 
           expect(subject.task_params).to eq(["--", {:uri => uri}])
         end
@@ -1137,7 +1125,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       context "when excluding tables" do
         it "asks to input tables, providing an example and sensible defaults" do
           say ["y", "metrics_*"]
-          subject.ask_for_tables_to_exclude_in_dump
+          expect(subject.ask_for_tables_to_exclude_in_dump).to be_truthy
           expect_output <<-EXAMPLE.strip_heredoc
 
             To exclude tables from the dump, enter them in a space separated
@@ -1157,14 +1145,14 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
           expect(subject).to receive(:ask_for_many).with("table", "tables to exclude", default_table_excludes, 255, Float::INFINITY).once.and_call_original
           say ["y", "metrics_* vms"]
 
-          subject.ask_for_tables_to_exclude_in_dump
+          expect(subject.ask_for_tables_to_exclude_in_dump).to be_truthy
           expect(subject.task_params).to eq(["--", {:uri => uri, :"exclude-table-data" => ["metrics_*", "vms"]}])
         end
 
         it "defaults to 'metrics_* vim_performance_states event_streams'" do
           say ["y", ""]
 
-          subject.ask_for_tables_to_exclude_in_dump
+          expect(subject.ask_for_tables_to_exclude_in_dump).to be_truthy
           expect(subject.task_params).to eq(["--", {:uri => uri, :"exclude-table-data" => ["metrics_*", "vim_performance_states", "event_streams"]}])
         end
       end


### PR DESCRIPTION
Fixes the following in `ManageIQ::ApplianceConsole::DatabaseAdmin`

* `LOCAL_FILE_VALIDATOR` for creating a `:dump` and a `:backup`, since it would check for the files existance when creating a new database dump/backup.
* The default for a local dump file is now `/tmp/evm_db.dump`, not `/tmp/evm_db.backup`
* Fix `ask_questions` so it returns true (breaks how things are written in `bin/appliance_console` otherwise)
* Fixes questions for `SMB` and `NFS` file locations to allow specifying the name of the `:remote_file_name` properly.

Testing
-------

I have been using the following gist to test these changes:

https://gist.github.com/NickLaMuro/8438015363d90a2d2456be650a2b9bc6

The tests are actually built around testing https://github.com/ManageIQ/manageiq-appliance_console/pull/50, but these changes are needed for any of that to work, and that PR is built on top of this one, so it has been helpful in making sure all the necessary changes are actually doing what I want.