### PR TITLE
Fixes signal trapping

### DIFF
--- a/bin/appliance_console
+++ b/bin/appliance_console
@@ -47,7 +47,7 @@ def ensure_key_configured
   end
 end
 
-[:INT, :TERM, :ABRT, :TSTP].each { |s| trap(s) { raise MiqSignalError } }
+[:INT, :TERM, :ABRT, :TSTP].each { |s| trap(s) { raise ManageIQ::ApplianceConsole::MiqSignalError } }
 
 VERSION_FILE  = ManageIQ::ApplianceConsole::RAILS_ROOT.join("VERSION")
 LOGFILE       = ManageIQ::ApplianceConsole::RAILS_ROOT.join("log", "appliance_console.log")


### PR DESCRIPTION
Namespacing the error class in the `trap` call allows the trap to work as expected again.


Background
----------

When this was initially extracted from the `manageiq-gems-pending` repo, `the lib/manageiq/appliance_console/errors.rb` looked like this:

```ruby
class MiqSignalError < RuntimeError; end
```

Link to the PR and removed file:

- https://github.com/ManageIQ/manageiq-gems-pending/pull/292
- https://github.com/ManageIQ/manageiq-gems-pending/pull/292/files#diff-4265a66ff1f90898eb4add59adb4c5ca

During the initial commits of the newly created repository, the errors.rb was namespaced:

https://github.com/ManageIQ/manageiq-appliance_console/commit/ff0dea9e#diff-30f4d0543374373ec9d55b71f7ce6301

But the `bin/appliance_console` in the that commit was not updated to reflect that.  Since the specs don't test against the `bin/appliance_console`, this was never noticed since `v1.0.0` of the gem.



QA steps
--------

- Open `appliance_console` on basically any `gaprindashvili` appliance
- After getting to the `Summary Information` screen, press `Ctrl-c`
- Press `Ctrl-c` again on the `Main Menu` ("Advanced Settings")


**Before**

Since it should not be working, it will take the `Ctrl-C` as input, and spew back all of the valid answers instead of returning you to the `Summary Information` screen.  Any sub menus you enter will also "barf" when `Ctrl-c` is pressed instead of ejecting from that sub menu.


**After**

If it was working, you could continue to press `Ctrl-C` and it would flip between `Summary Information` and `Advanced Settings` (probably not ideal... but at least what people expect I guess.  Any sub menus you enter should also eject and return you to `Summary Information` when `Ctrl-c` is pressed.