### PR TITLE
Use io/console instead of `stty`

### DIFF
--- a/lib/manageiq/appliance_console/prompts.rb
+++ b/lib/manageiq/appliance_console/prompts.rb
@@ -1,4 +1,5 @@
 require 'resolv'
+require 'io/console'
 
 module ManageIQ
 module ApplianceConsole
@@ -41,12 +42,7 @@ module ApplianceConsole
 
     def press_any_key
       say("\nPress any key to continue.")
-      begin
-        system("stty raw -echo")
-        STDIN.getc
-      ensure
-        system("stty -raw echo")
-      end
+      STDIN.noecho(&:getc)
     end
 
     def clear_screen


### PR DESCRIPTION
Since ruby-1.9.3, 'io/console' has been a part of ruby's stdlib:

https://svn.ruby-lang.org/repos/ruby/tags/v1_9_3_0/NEWS

This adds the `STDIN.noecho` when `io/console` is loaded, which effectively does the same as what we were doing with system calls, with the addition of also handling `signals` properly (which we were not doing, and would have needed the `isig` flag set to do so).

Combined with the block form of `STDIN.getc`, we can replicate what was being done previously, and avoid multiple system calls every time `press_any_key` was called.


Additional Information
----------------------

aka "the neckbeard section"...

So for those uninitiated (which for the most part was me prior to doing this), the `stty raw -echo` was doing two things to your terminal in the previous implementation of the `ManageIQ::ApplianceConsole::Prompts#press_any_key` method:

- `-echo`:  Turning off `echo`, so not echoing the output you type to your terminal
- `raw`:    Turning on `raw`, so treating the output from your terminal as raw input, and not doing anything with it (signal handling, etc.)

The docs for `raw` (and `isig`) specifically are below from the man pages:

```txt
...

   Local settings:
       [-]isig
               enable interrupt, quit, and suspend special characters

...

   Combination settings:
       raw    same as -ignbrk -brkint -ignpar -parmrk -inpck -istrip -inlcr -igncr -icrnl  -ixon  -ixoff  -iuclc  -ixany -imaxbel -opost -isig -icanon -xcase min 1 time 0
```

(notice the `-isig` near the end of `raw`)


`Highline` [does](https://github.com/JEG2/highline/blob/bf489b63/lib/highline/terminal/unix_stty.rb#L36) and [has done in our version](https://github.com/JEG2/highline/blob/v1.6.21/lib/highline/system_extensions.rb#L211) something similar to what we do here, but includes the `isig` after the raw, re-enabling the signal handling when doing anything that disables `echo`.

It also does something important that when re-enabling `stty echo`, it does `system("stty #{state}")`, in which `state` is `stty -g`, which is the current state of the `stty` prior to the "no echo" (something we probably should be doing as well).


The `STDIN.noecho(&:getc)` makes this all unnecessary, and newer versions of `Highline` will actually use this instead of `stty` in most places when available, unless you are using an old-a** version of ruby AND don't have the gem version of `io/console`.


QA Steps
--------

With the changes in place, just run the `appliance_console` and press any key once you reach the "Summary Information" page on first boot.  It should still bring you to the "Advanced Settings" like normal.