### PR TITLE
Enable DB Restore from S3

### DIFF
--- a/bin/appliance_console
+++ b/bin/appliance_console
@@ -67,7 +67,8 @@ include ManageIQ::ApplianceConsole::Prompts
 RESTORE_LOCAL   = "Local file".freeze
 RESTORE_NFS     = "Network File System (NFS)".freeze
 RESTORE_SMB     = "Samba (SMB)".freeze
-RESTORE_OPTIONS = [RESTORE_LOCAL, RESTORE_NFS, RESTORE_SMB, ManageIQ::ApplianceConsole::CANCEL].freeze
+RESTORE_S3      = "AWS S3 (S3)".freeze
+RESTORE_OPTIONS = [RESTORE_LOCAL, RESTORE_NFS, RESTORE_SMB, RESTORE_S3, ManageIQ::ApplianceConsole::CANCEL].freeze
 
 # Restart choices
 RE_RESTART  = "Restart".freeze

--- a/bin/appliance_console
+++ b/bin/appliance_console
@@ -67,8 +67,7 @@ include ManageIQ::ApplianceConsole::Prompts
 RESTORE_LOCAL   = "Local file".freeze
 RESTORE_NFS     = "Network File System (NFS)".freeze
 RESTORE_SMB     = "Samba (SMB)".freeze
-RESTORE_S3      = "AWS S3 (S3)".freeze
-RESTORE_OPTIONS = [RESTORE_LOCAL, RESTORE_NFS, RESTORE_SMB, RESTORE_S3, ManageIQ::ApplianceConsole::CANCEL].freeze
+RESTORE_OPTIONS = [RESTORE_LOCAL, RESTORE_NFS, RESTORE_SMB, ManageIQ::ApplianceConsole::CANCEL].freeze
 
 # Restart choices
 RE_RESTART  = "Restart".freeze

--- a/lib/manageiq/appliance_console/database_admin.rb
+++ b/lib/manageiq/appliance_console/database_admin.rb
@@ -105,7 +105,7 @@ module ManageIQ
         @uri         = ask_for_uri(*remote_file_prompt_args_for("s3"))
         user         = just_ask(access_key_prompt)
         pass         = ask_for_password("Secret Access Key for #{user}")
-        region       = ask_for_region("Amazon Region for database file")
+        region       = just_ask("Amazon Region for database file", "us-east-1")
 
         @task        = "evm:db:#{action}:remote"
         @task_params = [
@@ -114,7 +114,7 @@ module ManageIQ
             :uri          => uri,
             :uri_username => user,
             :uri_password => pass,
-            :uri_region   => region
+            :aws_region   => region
           }
         ]
       end

--- a/lib/manageiq/appliance_console/database_admin.rb
+++ b/lib/manageiq/appliance_console/database_admin.rb
@@ -20,11 +20,6 @@ module ManageIQ
         Example: 'mydomain.com/user'
       PROMPT
 
-      ACCESS_KEY_PROMPT = <<-PROMPT.strip_heredoc.chomp
-        Access Key ID with access to this file.
-        Example: 'amazon_aws_user'
-      PROMPT
-
       DB_DUMP_WARNING = <<-WARN.strip_heredoc
         WARNING:  This is not the recommended and supported way of running a
         database backup, and is strictly meant for exporting a database for
@@ -102,8 +97,13 @@ module ManageIQ
       end
 
       def ask_s3_file_options
+        access_key_prompt = <<-PROMPT.strip_heredoc.chomp
+          Access Key ID with access to this file.
+          Example: 'amazon_aws_user'
+        PROMPT
+
         @uri         = ask_for_uri(*remote_file_prompt_args_for("s3"))
-        user         = just_ask(ACCESS_KEY_PROMPT)
+        user         = just_ask(access_key_prompt)
         pass         = ask_for_password("Secret Access Key for #{user}")
         region       = ask_for_region("Amazon Region for database file")
 

--- a/lib/manageiq/appliance_console/prompts.rb
+++ b/lib/manageiq/appliance_console/prompts.rb
@@ -138,10 +138,6 @@ module ApplianceConsole
       pass == "********" ? (default || "") : pass
     end
 
-    def ask_for_region(prompt, default = "us-east-1")
-      just_ask(prompt, default)
-    end
-
     def ask_for_string(prompt, default = nil)
       just_ask(prompt, default)
     end

--- a/lib/manageiq/appliance_console/prompts.rb
+++ b/lib/manageiq/appliance_console/prompts.rb
@@ -18,6 +18,7 @@ module ApplianceConsole
     SAMPLE_URLS = {
       'nfs' => 'nfs://host.mydomain.com/exported/my_exported_folder/db.backup',
       'smb' => 'smb://host.mydomain.com/my_share/daily_backup/db.backup',
+      's3'  => 's3://mybucket/my_subdirectory/daily_backup/db.backup',
     }
 
     def sample_url(scheme)
@@ -135,6 +136,10 @@ module ApplianceConsole
         yield q if block_given?
       end
       pass == "********" ? (default || "") : pass
+    end
+
+    def ask_for_region(prompt, default = "us-east-1")
+      just_ask(prompt, default)
     end
 
     def ask_for_string(prompt, default = nil)

--- a/spec/database_admin_spec.rb
+++ b/spec/database_admin_spec.rb
@@ -54,7 +54,8 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
           1) Local file
           2) Network File System (NFS)
           3) Samba (SMB)
-          4) Cancel
+          4) Amazon S3 (S3)
+          5) Cancel
 
           Choose the restore database file: |1|
         PROMPT
@@ -88,8 +89,15 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         expect(subject.backup_type).to eq(described_class::SMB_FILE)
       end
 
-      it "cancels when CANCEL option is choosen" do
+      it "calls #ask_s3_file_options when choosen" do
+        expect(subject).to receive(:ask_s3_file_options).once
         say "4"
+        subject.ask_file_location
+        expect(subject.backup_type).to eq(described_class::S3_FILE)
+      end
+
+      it "cancels when CANCEL option is choosen" do
+        say "5"
         expect { subject.ask_file_location }.to raise_error signal_error
       end
     end
@@ -509,7 +517,8 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
           1) Local file
           2) Network File System (NFS)
           3) Samba (SMB)
-          4) Cancel
+          4) Amazon S3 (S3)
+          5) Cancel
 
           Choose the backup output file name: |1|
         PROMPT
@@ -543,8 +552,15 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         expect(subject.backup_type).to eq(described_class::SMB_FILE)
       end
 
-      it "cancels when CANCEL option is choosen" do
+      it "calls #ask_s3_file_options when choosen" do
+        expect(subject).to receive(:ask_s3_file_options).once
         say "4"
+        subject.ask_file_location
+        expect(subject.backup_type).to eq(described_class::S3_FILE)
+      end
+
+      it "cancels when CANCEL option is choosen" do
+        say "5"
         expect { subject.ask_file_location }.to raise_error signal_error
       end
     end
@@ -925,7 +941,8 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
           1) Local file
           2) Network File System (NFS)
           3) Samba (SMB)
-          4) Cancel
+          4) Amazon S3 (S3)
+          5) Cancel
 
           Choose the dump output file name: |1|
         PROMPT
@@ -960,7 +977,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       end
 
       it "cancels when CANCEL option is choosen" do
-        say "4"
+        say "5"
         expect { subject.ask_file_location }.to raise_error signal_error
       end
     end


### PR DESCRIPTION
Add an option to the DB Restore step to choose AWS S3 as the source of the database file from
which to restore.  Prompt for the AWS Region and credentials as well.

Requires https://github.com/ManageIQ/manageiq/pull/17827 as well which modifies
the rake db restore from remote step.

@NickLaMuro @carbonin @roliveri please review and merge when appropriate.

This is the last of the PRs for the RFE for S3 DB Backups in https://bugzilla.redhat.com/show_bug.cgi?id=1513520.