### PR TITLE
Fix reference to MiqSignalError in ensure_key_configured

### DIFF
--- a/bin/appliance_console
+++ b/bin/appliance_console
@@ -42,7 +42,7 @@ def ensure_key_configured
     else
       say("\nEncryption key not configured.")
       press_any_key
-      raise MiqSignalError
+      raise ManageIQ::ApplianceConsole::MiqSignalError
     end
   end
 end


### PR DESCRIPTION
Moving `ensure_key_configured` out of `ManageIQ::ApplianceConsole` scope introduced `ensure_key_configured: uninitialized constant MiqSignalError (NameError)`

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1596127

@miq-bot add-label bug