### PR TITLE
Fixed ApplianceConsole.press_any_key -  it should not wait until Enter pressed.

### DIFF
--- a/lib/manageiq/appliance_console/prompts.rb
+++ b/lib/manageiq/appliance_console/prompts.rb
@@ -43,7 +43,7 @@ module ApplianceConsole
 
     def press_any_key
       say("\nPress any key to continue.")
-      STDIN.noecho(&:getc)
+      STDIN.noecho(&:getch)
     end
 
     def clear_screen


### PR DESCRIPTION
This PR is small corrrection for https://github.com/ManageIQ/manageiq-appliance_console/pull/53/commits/3e84b566c92c0c74d245a284c36338b31dfe4d4c

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1616296

@miq-bot add-label bug