### PR TITLE
Adds :remote_file_name to task_params for DatabaseAdmin#ask_s3_file_options

### DIFF
--- a/lib/manageiq/appliance_console/database_admin.rb
+++ b/lib/manageiq/appliance_console/database_admin.rb
@@ -102,21 +102,22 @@ module ManageIQ
           Example: 'amazon_aws_user'
         PROMPT
 
+        @filename    = just_ask(*filename_prompt_args) unless action == :restore
         @uri         = ask_for_uri(*remote_file_prompt_args_for("s3"))
         region       = just_ask("Amazon Region for database file", "us-east-1")
         user         = just_ask(access_key_prompt)
         pass         = ask_for_password("Secret Access Key for #{user}")
 
+        params = {
+          :uri          => uri,
+          :uri_username => user,
+          :uri_password => pass,
+          :aws_region   => region
+        }
+        params[:remote_file_name] = filename if filename
+
         @task        = "evm:db:#{action}:remote"
-        @task_params = [
-          "--",
-          {
-            :uri          => uri,
-            :uri_username => user,
-            :uri_password => pass,
-            :aws_region   => region
-          }
-        ]
+        @task_params = ["--", params]
       end
 
       def ask_to_delete_backup_after_restore

--- a/lib/manageiq/appliance_console/database_admin.rb
+++ b/lib/manageiq/appliance_console/database_admin.rb
@@ -103,9 +103,9 @@ module ManageIQ
         PROMPT
 
         @uri         = ask_for_uri(*remote_file_prompt_args_for("s3"))
+        region       = just_ask("Amazon Region for database file", "us-east-1")
         user         = just_ask(access_key_prompt)
         pass         = ask_for_password("Secret Access Key for #{user}")
-        region       = just_ask("Amazon Region for database file", "us-east-1")
 
         @task        = "evm:db:#{action}:remote"
         @task_params = [

--- a/spec/database_admin_spec.rb
+++ b/spec/database_admin_spec.rb
@@ -844,17 +844,18 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         [
           "--",
           {
-            :uri          => uri,
-            :uri_username => access_key_id,
-            :uri_password => secret_access_key,
-            :aws_region   => region
+            :uri              => uri,
+            :uri_username     => access_key_id,
+            :uri_password     => secret_access_key,
+            :aws_region       => region,
+            :remote_file_name => filename
           }
         ]
       end
 
       context "with a valid uri, access_key_id, secret_access_key, and region given" do
         before do
-          say [uri, region, access_key_id, secret_access_key]
+          say [filename, uri, region, access_key_id, secret_access_key]
           expect(subject.ask_s3_file_options).to be_truthy
         end
 
@@ -863,7 +864,6 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         end
 
         it "sets @filename the name of the file in s3" do
-          pending "will fix in next commit"
           expect(subject.filename).to eq(filename)
         end
 
@@ -880,7 +880,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         let(:region) { "us-east-1" }
 
         before do
-          say [uri, "", access_key_id, secret_access_key]
+          say [filename, uri, "", access_key_id, secret_access_key]
           expect(subject.ask_s3_file_options).to be_truthy
         end
 
@@ -889,7 +889,6 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         end
 
         it "sets @filename the name of the file in s3" do
-          pending "will fix in next commit"
           expect(subject.filename).to eq(filename)
         end
 
@@ -906,7 +905,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         let(:bad_uri) { "nfs://host.mydomain.com/path/to/file" }
 
         before do
-          say [bad_uri, uri, region, access_key_id, secret_access_key]
+          say [filename, bad_uri, uri, region, access_key_id, secret_access_key]
           expect(subject.ask_s3_file_options).to be_truthy
         end
 
@@ -924,7 +923,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
           ]
 
           expect(subject.uri).to         eq(uri)
-          # expect(subject.filename).to    eq(filename)  (pending)
+          expect(subject.filename).to    eq(filename)
           expect(subject.task).to        eq("evm:db:backup:remote")
           expect(subject.task_params).to eq(expected_task_params)
         end


### PR DESCRIPTION
The way that backup/dump is handled for for the rake tasks, it expects that the `--uri` is the location of the "share" (in this case, the s3 bucket), and the `--remote-file-name` is used to define the file name:

https://github.com/ManageIQ/manageiq/blob/5c204228/lib/evm_database_ops.rb#L118-L120

Made more confusing I am sure with how the questions are asked in the DatabaseAdmin lib for the URI.  Admittedly I wrote a lot of this, but based it off of what was already there for the `restore` task, so I reserve some blame to what was there previously and me trying to stick to that interface...  (still my fault).

Without it, if you try and pass just the `--uri`.  For example `s3://bucketname/path/to/backup.tar.gz`) without a `--remote-file-name`, the result will end up as:

```
s3://buckname/path/to/backup.tar.gz/db_backup/miq_backup_20180101_000000
````

This will fix things by allowing the rake task to properly name the file, instead of using what was the default, and using the URI to set a base folder.

* * *

In addition, I have added some tests around this code, and had to slightly re-arrange some questions to allow those specs to work (see first commit message for more info).