### PR TITLE
Fix:  Make s3 uri paths optional

### DIFF
--- a/lib/manageiq/appliance_console/database_admin.rb
+++ b/lib/manageiq/appliance_console/database_admin.rb
@@ -103,7 +103,7 @@ module ManageIQ
         PROMPT
 
         @filename    = just_ask(*filename_prompt_args) unless action == :restore
-        @uri         = ask_for_uri(*remote_file_prompt_args_for("s3"))
+        @uri         = ask_for_uri(*remote_file_prompt_args_for("s3"), :optional_path => true)
         region       = just_ask("Amazon Region for database file", "us-east-1")
         user         = just_ask(access_key_prompt)
         pass         = ask_for_password("Secret Access Key for #{user}")

--- a/lib/manageiq/appliance_console/prompts.rb
+++ b/lib/manageiq/appliance_console/prompts.rb
@@ -25,7 +25,7 @@ module ApplianceConsole
       SAMPLE_URLS[scheme]
     end
 
-    def ask_for_uri(prompt, expected_scheme)
+    def ask_for_uri(prompt, expected_scheme, opts = {})
       require 'uri'
       just_ask(prompt, nil, nil, 'a valid URI') do |q|
         q.validate = lambda do |a|
@@ -36,7 +36,7 @@ module ApplianceConsole
           # validate it has a hostname/ip and a share
           u.scheme == expected_scheme &&
             (u.host =~ HOSTNAME_REGEXP || u.hostname =~ IP_REGEXP) &&
-            !u.path.empty?
+            (opts[:optional_path] || !u.path.empty?)
         end
       end
     end

--- a/spec/database_admin_spec.rb
+++ b/spec/database_admin_spec.rb
@@ -901,6 +901,33 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         end
       end
 
+      context "with an empty path URI" do
+        let(:uri)         { 's3://mybucket' }
+        let(:filename)    { 'database_backup.tar.gz' }
+        let(:example_uri) { subject.sample_url('s3') }
+
+        before do
+          say [filename, uri, region, access_key_id, secret_access_key]
+          expect(subject.ask_s3_file_options).to be_truthy
+        end
+
+        it "sets @uri to point to the s3 share url" do
+          expect(subject.uri).to eq(uri)
+        end
+
+        it "sets @filename the name of the file in s3" do
+          expect(subject.filename).to eq(filename)
+        end
+
+        it "sets @task to point to 'evm:db:backup:remote'" do
+          expect(subject.task).to eq("evm:db:backup:remote")
+        end
+
+        it "sets @task_params to point to the s3 file, access_key_id, and secret_access_key" do
+          expect(subject.task_params).to eq(expected_task_params)
+        end
+      end
+
       context "with a invalid uri given" do
         let(:bad_uri) { "nfs://host.mydomain.com/path/to/file" }
 


### PR DESCRIPTION
Built off of #57 (merge that first)

Based on the format provided in the sample URL for s3:

```
s3://mybucket/path/to/file
```

and how the implementation is coded up in `MiqS3Session`, the bucket name is plucked from the host (which can just be the bucket name, and not the hostname like `bucketname.s3.amazonaws.com`).  In the case of s3, if no path is provided to the URL, it means that the resulting directory is top level, which is should be valid.

This fix simply allows that functionality by updating the `ask_for_uri` validator to all no paths in the uri conditionally (based on an argument option) and hooks up the `#ask_s3_file_options` method to use this new flag.  All other uses of `#ask_for_uri` should still function as they did.


Links
-----

* https://github.com/ManageIQ/manageiq-appliance_console/pull/57
* Diff:  https://github.com/NickLaMuro/manageiq-appliance_console/compare/fix-s3-options-for-database-admin...fix-s3-uri-validation