### PR TITLE
Ensure #validate_encryption_key! returns true when successful

### DIFF
--- a/lib/manageiq/appliance_console/database_configuration.rb
+++ b/lib/manageiq/appliance_console/database_configuration.rb
@@ -269,6 +269,7 @@ FRIENDLY
 
     def validate_encryption_key!
       raise "Encryption key invalid" unless ManageIQ::ApplianceConsole::Utilities.rake("evm:validate_encryption_key", {})
+      true
     end
 
     def do_save(settings)

--- a/spec/database_configuration_spec.rb
+++ b/spec/database_configuration_spec.rb
@@ -345,7 +345,7 @@ describe ManageIQ::ApplianceConsole::DatabaseConfiguration do
       it "normal case" do
         allow(@config).to receive_messages(:validated => true)
         expect(@config).to receive(:create_or_join_region).and_return(true)
-        expect(@config).to receive(:validate_encryption_key!).and_return(true)
+        expect(ManageIQ::ApplianceConsole::Utilities).to receive(:rake).with("evm:validate_encryption_key", {}).and_return(true)
 
         allow(@config).to receive_messages(:merged_settings => @settings)
         expect(@config).to receive(:do_save).with(@settings)


### PR DESCRIPTION
Before this, #validate_encryption_key! would return nil when successful
because of the way the conditional was written, now if the rake task
succeeds, we will return true.

Introduced in #34