### PR TITLE
Update summary to report OIDC or SAML configured

### DIFF
--- a/lib/manageiq/appliance_console/external_httpd_authentication/external_httpd_configuration.rb
+++ b/lib/manageiq/appliance_console/external_httpd_authentication/external_httpd_configuration.rb
@@ -221,10 +221,10 @@ module ApplianceConsole
 
     def self.config_status
       fetch_ipa_configuration("ipa_server") ||
-      fetch_sssd_domain ||
-      fetch_oidc_configured? ||
-      fetch_saml_configured? ||
-      "not configured"
+        fetch_sssd_domain                   ||
+        fetch_oidc_configured?              ||
+        fetch_saml_configured?              ||
+        "not configured"
     end
 
     def self.ipa_client_configured?

--- a/lib/manageiq/appliance_console/external_httpd_authentication/external_httpd_configuration.rb
+++ b/lib/manageiq/appliance_console/external_httpd_authentication/external_httpd_configuration.rb
@@ -222,8 +222,8 @@ module ApplianceConsole
     def self.config_status
       fetch_ipa_configuration("ipa_server") ||
         fetch_sssd_domain                   ||
-        fetch_oidc_configured?              ||
-        fetch_saml_configured?              ||
+        oidc_status                         ||
+        saml_status                         ||
         "not configured"
     end
 
@@ -248,11 +248,11 @@ module ApplianceConsole
       config_file_read(SSSD_CONFIG)[/\[domain\/(.*)\]/, 1] if File.exist?(SSSD_CONFIG)
     end
 
-    def self.fetch_saml_configured?
+    def self.saml_status
       "External Auth SAML" if File.exist?(HTTP_REMOTE_USER)
     end
 
-    def self.fetch_oidc_configured?
+    def self.oidc_status
       "External Auth OpenID Connect" if File.exist?(HTTP_REMOTE_USER_OIDC)
     end
 

--- a/lib/manageiq/appliance_console/external_httpd_authentication/external_httpd_configuration.rb
+++ b/lib/manageiq/appliance_console/external_httpd_authentication/external_httpd_configuration.rb
@@ -8,28 +8,29 @@ module ApplianceConsole
       #
       # External Authentication Definitions
       #
-      IPA_COMMAND          = "/usr/bin/ipa".freeze
-      IPA_INSTALL_COMMAND  = "/usr/sbin/ipa-client-install".freeze
-      IPA_GETKEYTAB        = "/usr/sbin/ipa-getkeytab".freeze
+      IPA_COMMAND           = "/usr/bin/ipa".freeze
+      IPA_INSTALL_COMMAND   = "/usr/sbin/ipa-client-install".freeze
+      IPA_GETKEYTAB         = "/usr/sbin/ipa-getkeytab".freeze
 
-      KERBEROS_CONFIG_FILE = "/etc/krb5.conf".freeze
+      KERBEROS_CONFIG_FILE  = "/etc/krb5.conf".freeze
 
-      SSSD_CONFIG          = "/etc/sssd/sssd.conf".freeze
-      PAM_CONFIG           = "/etc/pam.d/httpd-auth".freeze
-      HTTP_KEYTAB          = "/etc/http.keytab".freeze
-      HTTP_REMOTE_USER     = "/etc/httpd/conf.d/manageiq-remote-user.conf".freeze
-      HTTP_EXTERNAL_AUTH   = "/etc/httpd/conf.d/manageiq-external-auth.conf".freeze
+      SSSD_CONFIG           = "/etc/sssd/sssd.conf".freeze
+      PAM_CONFIG            = "/etc/pam.d/httpd-auth".freeze
+      HTTP_KEYTAB           = "/etc/http.keytab".freeze
+      HTTP_REMOTE_USER      = "/etc/httpd/conf.d/manageiq-remote-user.conf".freeze
+      HTTP_REMOTE_USER_OIDC = "/etc/httpd/conf.d/manageiq-remote-user-openidc.conf".freeze
+      HTTP_EXTERNAL_AUTH    = "/etc/httpd/conf.d/manageiq-external-auth.conf".freeze
       HTTP_EXTERNAL_AUTH_TEMPLATE = "#{HTTP_EXTERNAL_AUTH}.erb".freeze
 
-      GETSEBOOL_COMMAND    = "/usr/sbin/getsebool".freeze
-      SETSEBOOL_COMMAND    = "/usr/sbin/setsebool".freeze
-      GETENFORCE_COMMAND   = "/usr/sbin/getenforce".freeze
+      GETSEBOOL_COMMAND     = "/usr/sbin/getsebool".freeze
+      SETSEBOOL_COMMAND     = "/usr/sbin/setsebool".freeze
+      GETENFORCE_COMMAND    = "/usr/sbin/getenforce".freeze
 
-      APACHE_USER          = "apache".freeze
+      APACHE_USER           = "apache".freeze
 
-      TIMESTAMP_FORMAT     = "%Y%m%d_%H%M%S".freeze
+      TIMESTAMP_FORMAT      = "%Y%m%d_%H%M%S".freeze
 
-      LDAP_ATTRS           = {
+      LDAP_ATTRS            = {
         "mail"        => "REMOTE_USER_EMAIL",
         "givenname"   => "REMOTE_USER_FIRSTNAME",
         "sn"          => "REMOTE_USER_LASTNAME",
@@ -219,7 +220,11 @@ module ApplianceConsole
     end
 
     def self.config_status
-      fetch_ipa_configuration("ipa_server") || fetch_sssd_domain || "not configured"
+      fetch_ipa_configuration("ipa_server") ||
+      fetch_sssd_domain ||
+      fetch_oidc_configured? ||
+      fetch_saml_configured? ||
+      "not configured"
     end
 
     def self.ipa_client_configured?
@@ -241,6 +246,14 @@ module ApplianceConsole
 
     def self.fetch_sssd_domain
       config_file_read(SSSD_CONFIG)[/\[domain\/(.*)\]/, 1] if File.exist?(SSSD_CONFIG)
+    end
+
+    def self.fetch_saml_configured?
+      "External Auth SAML" if File.exist?(HTTP_REMOTE_USER)
+    end
+
+    def self.fetch_oidc_configured?
+      "External Auth OpenID Connect" if File.exist?(HTTP_REMOTE_USER_OIDC)
     end
 
     delegate :ipa_client_configured?, :config_file_read, :fetch_ipa_configuration, :config_status, :to => self

--- a/spec/external_httpd_authentication_spec.rb
+++ b/spec/external_httpd_authentication_spec.rb
@@ -1,6 +1,11 @@
 describe ManageIQ::ApplianceConsole::ExternalHttpdAuthentication do
   let(:host) { "this.server.com" }
+  let(:external_auth_config) { Tempfile.new(@spec_name.downcase) }
   subject { described_class.new(host) }
+
+  before do
+    @spec_name = File.basename(__FILE__).split(".rb").first.freeze
+  end
 
   context "#domain_from_host" do
     it "should be blank for blank" do
@@ -176,6 +181,22 @@ describe ManageIQ::ApplianceConsole::ExternalHttpdAuthentication do
                                                              :params     => ["admin"],
                                                              :stdin_data => "$my_password")
       subject.send(:configure_ipa_http_service)
+    end
+  end
+
+  context "#config_status" do
+    it "Returns not configured" do
+      expect(described_class.config_status).to eq("not configured")
+    end
+
+    it "Returns OpenID Connect configured" do
+      stub_const("ManageIQ::ApplianceConsole::ExternalHttpdAuthentication::ExternalHttpdConfiguration::HTTP_REMOTE_USER_OIDC", external_auth_config)
+      expect(described_class.config_status).to eq("External Auth OpenID Connect")
+    end
+
+    it "Returns SAML configured" do
+      stub_const("ManageIQ::ApplianceConsole::ExternalHttpdAuthentication::ExternalHttpdConfiguration::HTTP_REMOTE_USER", external_auth_config)
+      expect(described_class.config_status).to eq("External Auth SAML")
     end
   end
 end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1438546

The appliance console falsely reported that external authentication was not configured when it actually was for OpenID Connect or SAML.

This PR adds support to check of the httpd remote user configuration file used for each of these external authentication options has been created.

It is possible that the user could configure then and then use the UI to un-configure external authentication and not remove the httpd remote user file(s) and the appliance console would
erroneously report external authentication was still configured.

However this is also the case with the current functionality for the sssd.conf file. So this PR
does no more harm than what already exists and it adds the benefit if reporting SAML and/or
OIDC configured when they are.