### PR TITLE
Reword Local Login prompt to indicate it's for SAML or OIDC

### DIFF
--- a/lib/manageiq/appliance_console/external_auth_options.rb
+++ b/lib/manageiq/appliance_console/external_auth_options.rb
@@ -7,10 +7,10 @@ module ApplianceConsole
     AUTH_PATH = "/authentication".freeze
 
     EXT_AUTH_OPTIONS = {
-      "#{AUTH_PATH}/sso_enabled"          => {:label => "Single Sign-On", :logic  => true},
-      "#{AUTH_PATH}/saml_enabled"         => {:label => "SAML",           :logic  => true},
-      "#{AUTH_PATH}/oidc_enabled"         => {:label => "OIDC",           :logic  => true},
-      "#{AUTH_PATH}/local_login_disabled" => {:label => "Local Login",    :logic  => false}
+      "#{AUTH_PATH}/sso_enabled"          => {:label => "Single Sign-On",               :logic  => true},
+      "#{AUTH_PATH}/saml_enabled"         => {:label => "SAML",                         :logic  => true},
+      "#{AUTH_PATH}/oidc_enabled"         => {:label => "OIDC",                         :logic  => true},
+      "#{AUTH_PATH}/local_login_disabled" => {:label => "Local Login for SAML or OIDC", :logic  => false}
     }.freeze
 
     include ManageIQ::ApplianceConsole::Logging


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1446704

This BZ stated that the wording of the `Enable/Disable Local Login` was confusing since this
option only takes effect when configured for SAML or OIDC.

This PR introduces a very minor wording change to clarify this point.