### PR TITLE
Don't return empty params when when not altering provider type.

### DIFF
--- a/lib/manageiq/appliance_console/external_auth_options.rb
+++ b/lib/manageiq/appliance_console/external_auth_options.rb
@@ -100,6 +100,8 @@ module ApplianceConsole
         configure_oidc!(params)
       elsif params.include?("/authentication/oidc_enabled=false") || params.include?("/authentication/saml_enabled=false")
         configure_none!(params)
+      else
+        params
       end
     end
 

--- a/spec/external_auth_options_spec.rb
+++ b/spec/external_auth_options_spec.rb
@@ -1,0 +1,67 @@
+describe ManageIQ::ApplianceConsole::ExternalAuthOptions do
+  subject { described_class.new }
+  let(:result) { double(@spec_name, :failure? => false) }
+  let(:rake_set) { "evm:settings:set" }
+
+  before do
+    @spec_name = File.basename(__FILE__).split(".rb").first.freeze
+    allow(subject).to receive(:say)
+  end
+
+  context "#update_configuration" do
+    it "will toggle SSO when provided alone" do
+      sso_alone = {"/authentication/sso_enabled" => true}
+      expected_params = sso_alone.collect { |key, value| "#{key}=#{value}" }
+      expect(ManageIQ::ApplianceConsole::Utilities).to receive(:rake_run).with(rake_set, expected_params).and_return(result)
+      subject.update_configuration(sso_alone)
+    end
+
+    it "will toggle SSO when provided with provider type oidc" do
+      sso_with_oidc = {"/authentication/sso_enabled" => true, "/authentication/oidc_enabled" => true}
+      expected_params = sso_with_oidc.collect { |key, value| "#{key}=#{value}" }
+      expected_params << "/authentication/saml_enabled=false"
+      expected_params << "/authentication/provider_type=oidc"
+
+      expect(ManageIQ::ApplianceConsole::Utilities).to receive(:rake_run).with(rake_set, expected_params).and_return(result)
+      subject.update_configuration(sso_with_oidc)
+    end
+
+    it "will toggle Local Login when provided alone" do
+      loacl_login_alone = {"/authentication/local_login_disabled" => true}
+      expected_params = loacl_login_alone.collect { |key, value| "#{key}=#{value}" }
+      expect(ManageIQ::ApplianceConsole::Utilities).to receive(:rake_run).with(rake_set, expected_params).and_return(result)
+      subject.update_configuration(loacl_login_alone)
+    end
+
+    it "will set provider type oidc" do
+      oidc = {"/authentication/oidc_enabled" => true}
+      expected_params = oidc.collect { |key, value| "#{key}=#{value}" }
+      expected_params << "/authentication/saml_enabled=false"
+      expected_params << "/authentication/provider_type=oidc"
+
+      expect(ManageIQ::ApplianceConsole::Utilities).to receive(:rake_run).with(rake_set, expected_params).and_return(result)
+      subject.update_configuration(oidc)
+    end
+
+    it "will set provider type saml" do
+      saml = {"/authentication/saml_enabled" => true}
+      expected_params = saml.collect { |key, value| "#{key}=#{value}" }
+      expected_params << "/authentication/oidc_enabled=false"
+      expected_params << "/authentication/provider_type=saml"
+
+      expect(ManageIQ::ApplianceConsole::Utilities).to receive(:rake_run).with(rake_set, expected_params).and_return(result)
+      subject.update_configuration(saml)
+    end
+
+    it "will set provider type none" do
+      none = {"/authentication/saml_enabled" => false, "/authentication/oidc_enabled" => false}
+      expected_params = none.collect { |key, value| "#{key}=#{value}" }
+      expected_params << "/authentication/oidc_enabled=false"
+      expected_params << "/authentication/saml_enabled=false"
+      expected_params << "/authentication/provider_type=none"
+
+      expect(ManageIQ::ApplianceConsole::Utilities).to receive(:rake_run).with(rake_set, expected_params).and_return(result)
+      subject.update_configuration(none)
+    end
+  end
+end

--- a/spec/external_auth_options_spec.rb
+++ b/spec/external_auth_options_spec.rb
@@ -1,10 +1,9 @@
 describe ManageIQ::ApplianceConsole::ExternalAuthOptions do
   subject { described_class.new }
-  let(:result) { double(@spec_name, :failure? => false) }
+  let(:result) { double("RakeResult", :failure? => false) }
   let(:rake_set) { "evm:settings:set" }
 
   before do
-    @spec_name = File.basename(__FILE__).split(".rb").first.freeze
     allow(subject).to receive(:say)
   end
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1619662

[PR 48](https://github.com/ManageIQ/manageiq-appliance_console/pull/48) introduced a failure where if the provider type was not being modified the modification params were inadvertently cleared. So no external authentication params could be altered unless the provider type settings
were also being altered.

The fix is to simply return the unaltered params list from method `configure_provider_type!` when no provider type modifications are being done.

This impacted toggling both SSO and Local Login even though the BZ only mentions SSO.