### PR TITLE
Adds FTP support to backup/dump/restore

### DIFF
--- a/lib/manageiq/appliance_console/prompts.rb
+++ b/lib/manageiq/appliance_console/prompts.rb
@@ -19,6 +19,7 @@ module ApplianceConsole
       'nfs' => 'nfs://host.mydomain.com/exported/my_exported_folder/db.backup',
       'smb' => 'smb://host.mydomain.com/my_share/daily_backup/db.backup',
       's3'  => 's3://mybucket/my_subdirectory/daily_backup/db.backup',
+      'ftp' => 'ftp://host.mydomain.com/path/to/daily_backup/db.backup'
     }
 
     def sample_url(scheme)


### PR DESCRIPTION
Built off of https://github.com/ManageIQ/manageiq-appliance_console/pull/50

Adds questions for asking for FTP based options for appliance console DatabaseAdmin tasks (restore, backup, and dump)


Links
-----
* https://bugzilla.redhat.com/show_bug.cgi?id=1586187
* Relies on the following to be merged to function:
  - https://github.com/ManageIQ/manageiq-appliance_console/pull/50