### PR TITLE
Anonymous FTP upload

### DIFF
--- a/lib/manageiq/appliance_console/database_admin.rb
+++ b/lib/manageiq/appliance_console/database_admin.rb
@@ -29,6 +29,13 @@ module ManageIQ
 
       WARN
 
+      SAMPLE_URLS = {
+        'nfs' => 'nfs://host.mydomain.com/exported/my_exported_folder/db.backup',
+        'smb' => 'smb://host.mydomain.com/my_share/daily_backup/db.backup',
+        's3'  => 's3://mybucket/my_subdirectory/daily_backup/db.backup',
+        'ftp' => 'ftp://host.mydomain.com/path/to/daily_backup/db.backup'
+      }
+
       attr_reader :action, :backup_type, :task, :task_params, :delete_agree, :uri, :filename
 
       def initialize(action = :restore, input = $stdin, output = $stdout)
@@ -232,8 +239,12 @@ module ManageIQ
                   else
                     "location to save the remote #{action} file to"
                   end
-        prompt += "\nExample: #{SAMPLE_URLS[remote_type]}"
+        prompt += "\nExample: #{sample_url(remote_type)}"
         [prompt, remote_type]
+      end
+
+      def sample_url(scheme)
+        SAMPLE_URLS[scheme]
       end
 
       def processing_message

--- a/lib/manageiq/appliance_console/prompts.rb
+++ b/lib/manageiq/appliance_console/prompts.rb
@@ -15,17 +15,6 @@ module ApplianceConsole
     NONE_REGEXP   = /^('?NONE'?)?$/i.freeze
     HOSTNAME_REGEXP = /^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$/
 
-    SAMPLE_URLS = {
-      'nfs' => 'nfs://host.mydomain.com/exported/my_exported_folder/db.backup',
-      'smb' => 'smb://host.mydomain.com/my_share/daily_backup/db.backup',
-      's3'  => 's3://mybucket/my_subdirectory/daily_backup/db.backup',
-      'ftp' => 'ftp://host.mydomain.com/path/to/daily_backup/db.backup'
-    }
-
-    def sample_url(scheme)
-      SAMPLE_URLS[scheme]
-    end
-
     def ask_for_uri(prompt, expected_scheme, opts = {})
       require 'uri'
       just_ask(prompt, nil, nil, 'a valid URI') do |q|

--- a/locales/appliance/en.yml
+++ b/locales/appliance/en.yml
@@ -42,3 +42,20 @@ en:
     shutdown: Shut Down Appliance
     summary: Summary Information
     quit: Quit
+  database_admin:
+    menu_order:
+    - local
+    - nfs
+    - smb
+    - s3
+    - ftp
+    local: Local file
+    nfs: Network File System (NFS)
+    smb: Samba (SMB)
+    s3: Amazon S3 (S3)
+    ftp: File Transfer Protocol (FTP)
+    sample_url:
+      nfs: nfs://host.mydomain.com/exported/my_exported_folder/db.backup
+      smb: smb://host.mydomain.com/my_share/daily_backup/db.backup
+      s3: s3://mybucket/my_subdirectory/daily_backup/db.backup
+      ftp: ftp://host.mydomain.com/path/to/daily_backup/db.backup

--- a/spec/database_admin_spec.rb
+++ b/spec/database_admin_spec.rb
@@ -171,9 +171,9 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
     end
 
     describe "#ask_nfs_file_options" do
-      let(:uri)         { File.dirname(subject.sample_url('nfs')) }
-      let(:filename)    { File.basename(subject.sample_url('nfs')) }
-      let(:example_uri) { File.join(uri, filename) }
+      let(:example_uri) { subject.send(:sample_url, 'nfs') }
+      let(:uri)         { File.dirname(example_uri) }
+      let(:filename)    { File.basename(example_uri) }
       let(:prmpt)       { "location of the remote backup file\nExample: #{example_uri}" }
       let(:errmsg)      { "a valid URI" }
 
@@ -219,9 +219,9 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
     end
 
     describe "#ask_smb_file_options" do
-      let(:uri)         { File.dirname(subject.sample_url('smb')) }
-      let(:filename)    { File.basename(subject.sample_url('smb')) }
-      let(:example_uri) { File.join(uri, filename) }
+      let(:example_uri) { subject.send(:sample_url, 'smb') }
+      let(:uri)         { File.dirname(example_uri) }
+      let(:filename)    { File.basename(example_uri) }
       let(:user)        { 'example.com/admin' }
       let(:pass)        { 'supersecret' }
       let(:uri_prompt)  { "Enter the location of the remote backup file\nExample: #{example_uri}" }
@@ -292,9 +292,9 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
     end
 
     describe "#ask_s3_file_options" do
-      let(:uri)               { File.dirname(subject.sample_url('s3')) }
-      let(:filename)          { File.basename(subject.sample_url('s3')) }
-      let(:example_uri)       { File.join(uri, filename) }
+      let(:example_uri) { subject.send(:sample_url, 's3') }
+      let(:uri)         { File.dirname(example_uri) }
+      let(:filename)    { File.basename(example_uri) }
       let(:access_key_id)     { 'foobar' }
       let(:secret_access_key) { 'supersecret' }
       let(:region)            { 'us-east-2' }
@@ -394,9 +394,9 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
     end
 
     describe "#ask_ftp_file_options" do
-      let(:uri)         { File.dirname(subject.sample_url('ftp')) }
-      let(:filename)    { File.basename(subject.sample_url('ftp')) }
-      let(:example_uri) { File.join(uri, filename) }
+      let(:example_uri) { subject.send(:sample_url, 'ftp') }
+      let(:uri)         { File.dirname(example_uri) }
+      let(:filename)    { File.basename(example_uri) }
       let(:user)        { 'admin' }
       let(:pass)        { 'supersecret' }
       let(:uri_prompt)  { "Enter the location of the remote backup file\nExample: #{example_uri}" }
@@ -831,9 +831,9 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
     end
 
     describe "#ask_nfs_file_options" do
-      let(:uri)         { File.dirname(subject.sample_url('nfs')) }
-      let(:filename)    { File.basename(subject.sample_url('nfs')) }
-      let(:example_uri) { File.join(uri, filename) }
+      let(:example_uri) { subject.send(:sample_url, 'nfs') }
+      let(:uri)         { File.dirname(example_uri) }
+      let(:filename)    { File.basename(example_uri) }
       let(:prmpt)       { "location to save the remote backup file to\nExample: #{example_uri}" }
       let(:errmsg)      { "a valid URI" }
 
@@ -881,9 +881,9 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
     end
 
     describe "#ask_smb_file_options" do
-      let(:uri)         { File.dirname(subject.sample_url('smb')) }
-      let(:filename)    { File.basename(subject.sample_url('smb')) }
-      let(:example_uri) { File.join(uri, filename) }
+      let(:example_uri) { subject.send(:sample_url, 'smb') }
+      let(:uri)         { File.dirname(example_uri) }
+      let(:filename)    { File.basename(example_uri) }
       let(:user)        { 'example.com/admin' }
       let(:pass)        { 'supersecret' }
       let(:file_prompt) { "location to save the backup file to" }
@@ -957,9 +957,9 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
     end
 
     describe "#ask_s3_file_options" do
-      let(:uri)               { File.dirname(subject.sample_url('s3')) }
-      let(:filename)          { File.basename(subject.sample_url('s3')) }
-      let(:example_uri)       { File.join(uri, filename) }
+      let(:example_uri) { subject.send(:sample_url, 's3') }
+      let(:uri)         { File.dirname(example_uri) }
+      let(:filename)    { File.basename(example_uri) }
       let(:access_key_id)     { 'foobar' }
       let(:secret_access_key) { 'supersecret' }
       let(:region)            { 'us-east-2' }
@@ -1033,7 +1033,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       context "with an empty path URI" do
         let(:uri)         { 's3://mybucket' }
         let(:filename)    { 'database_backup.tar.gz' }
-        let(:example_uri) { subject.sample_url('s3') }
+        let(:example_uri) { subject.send(:sample_url, 's3') }
 
         before do
           say [filename, uri, region, access_key_id, secret_access_key]
@@ -1087,9 +1087,9 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
     end
 
     describe "#ask_ftp_file_options" do
-      let(:uri)         { File.dirname(subject.sample_url('ftp')) }
-      let(:filename)    { File.basename(subject.sample_url('ftp')) }
-      let(:example_uri) { File.join(uri, filename) }
+      let(:example_uri) { subject.send(:sample_url, 'ftp') }
+      let(:uri)         { File.dirname(example_uri) }
+      let(:filename)    { File.basename(example_uri) }
       let(:user)        { 'admin' }
       let(:pass)        { 'supersecret' }
       let(:uri_prompt)  { "Enter the location to save the remote backup file to\nExample: #{example_uri}" }
@@ -1501,9 +1501,9 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
     end
 
     describe "#ask_nfs_file_options" do
-      let(:uri)         { File.dirname(subject.sample_url('nfs')) }
-      let(:filename)    { File.basename(subject.sample_url('nfs')) }
-      let(:example_uri) { File.join(uri, filename) }
+      let(:example_uri) { subject.send(:sample_url, 'nfs') }
+      let(:uri)         { File.dirname(example_uri) }
+      let(:filename)    { File.basename(example_uri) }
       let(:prmpt)       { "location to save the remote dump file to\nExample: #{example_uri}" }
       let(:errmsg)      { "a valid URI" }
 
@@ -1549,9 +1549,9 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
     end
 
     describe "#ask_smb_file_options" do
-      let(:uri)         { File.dirname(subject.sample_url('smb')) }
-      let(:filename)    { File.basename(subject.sample_url('smb')) }
-      let(:example_uri) { File.join(uri, filename) }
+      let(:example_uri) { subject.send(:sample_url, 'smb') }
+      let(:uri)         { File.dirname(example_uri) }
+      let(:filename)    { File.basename(example_uri) }
       let(:user)        { 'example.com/admin' }
       let(:pass)        { 'supersecret' }
       let(:file_prompt) { "location to save the dump file to" }
@@ -1625,9 +1625,9 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
     end
 
     describe "#ask_ftp_file_options" do
-      let(:uri)         { File.dirname(subject.sample_url('ftp')) }
-      let(:filename)    { File.basename(subject.sample_url('ftp')) }
-      let(:example_uri) { File.join(uri, filename) }
+      let(:example_uri) { subject.send(:sample_url, 'ftp') }
+      let(:uri)         { File.dirname(example_uri) }
+      let(:filename)    { File.basename(example_uri) }
       let(:user)        { 'admin' }
       let(:pass)        { 'supersecret' }
       let(:uri_prompt)  { "Enter the location to save the remote dump file to\nExample: #{example_uri}" }
@@ -1952,6 +1952,17 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
           end
         end
       end
+    end
+  end
+
+  # private, but moved out of prompt and keeping tests around
+  describe "#sample_url" do
+    it "should show an example for nfs" do
+      expect(subject.send(:sample_url, 'nfs')).to match(%r{nfs://})
+    end
+
+    it "should show an example for smb" do
+      expect(subject.send(:sample_url, 'smb')).to match(%r{smb://})
     end
   end
 end

--- a/spec/prompts_spec.rb
+++ b/spec/prompts_spec.rb
@@ -5,16 +5,6 @@ describe ManageIQ::ApplianceConsole::Prompts, :with_ui do
     Class.new(HighLine) { include ManageIQ::ApplianceConsole::Prompts }.new(input, output)
   end
 
-  context "#sample_url" do
-    it "should show an example for nfs" do
-      expect(subject.sample_url('nfs')).to match(%r{nfs://})
-    end
-
-    it "should show an example for smb" do
-      expect(subject.sample_url('smb')).to match(%r{smb://})
-    end
-  end
-
   context "#ask_for_remote_backup_uri" do
     it "should ask for smb uri" do
       response = "smb://host.com/path/file.txt"


### PR DESCRIPTION
This will allow customers to upload files to support sites like `dropbox.redhat.com`

To add this option, add to `en.yml`:

```yml
  database_admin:
    menu_order:
    - local
    - ftp://ftp.example.com/incoming/999999-db.backup
    local: Local file
    prompts:
      ftp.example.com:
        filename_text: "The case number dash (-) filename. (e.g.: 12345-db.backup)"
        filename_validator: "^[0-9]{4,}-..*"
```

https://bugzilla.redhat.com/show_bug.cgi?id=1632433
