### PR TITLE
Support for Swift Backup/Restore

### DIFF
--- a/lib/manageiq/appliance_console/database_admin.rb
+++ b/lib/manageiq/appliance_console/database_admin.rb
@@ -258,7 +258,7 @@ module ManageIQ
       def api_version_menu_args
         [
           "OpenStack API Version",
-          API_VERSION_OPTIONS,
+          [["Keystone v2".freeze, "v2".freeze], ["Keystone v3".freeze, "v3".freeze], [CANCEL, nil]].freeze,
           ["Keystone v2".freeze, "v2".freeze],
           nil
         ]
@@ -276,7 +276,7 @@ module ManageIQ
       def security_protocol_menu_args
         [
           "OpenStack Security Protocol",
-          SECURITY_PROTOCOL_OPTIONS,
+          [["SSL without validation".freeze, "ssl".freeze], ["SSL".freeze, "ssl-with-validation".freeze], ["Non-SSL".freeze, "non-ssl".freeze], [CANCEL, nil]].freeze,
           ["Non-SSL".freeze, "non-ssl".freeze],
           nil
         ]

--- a/lib/manageiq/appliance_console/database_admin.rb
+++ b/lib/manageiq/appliance_console/database_admin.rb
@@ -6,19 +6,6 @@ module ManageIQ
     class DatabaseAdmin < HighLine
       include ManageIQ::ApplianceConsole::Prompts
 
-      V2_VERSION_PROMPT   = "Keystone v2".freeze
-      V2_VERSION          = "v2".freeze
-      V3_VERSION_PROMPT   = "Keystone v3".freeze
-      V3_VERSION          = "v3".freeze
-      API_VERSION_OPTIONS = [[V2_VERSION_PROMPT, V2_VERSION], [V3_VERSION_PROMPT, V3_VERSION], [CANCEL, nil]].freeze
-
-      SSL_WO_VALIDATION_PROMPT   = "SSL without validation".freeze
-      SSL_WO_VALIDATION          = "ssl".freeze
-      SSL_WITH_VALIDATION_PROMPT = "SSL".freeze
-      SSL_WITH_VALIDATION        = "ssl-with-validation".freeze
-      NON_SSL_PROMPT             = "Non-SSL".freeze
-      NON_SSL                    = "non-ssl".freeze
-      SECURITY_PROTOCOL_OPTIONS  = [[SSL_WO_VALIDATION_PROMPT, SSL_WO_VALIDATION], [SSL_WITH_VALIDATION_PROMPT, SSL_WITH_VALIDATION], [NON_SSL_PROMPT, NON_SSL], [CANCEL, nil]].freeze
       DB_RESTORE_FILE      = "/tmp/evm_db.backup".freeze
       DB_DEFAULT_DUMP_FILE = "/tmp/evm_db.dump".freeze
       LOCAL_FILE_VALIDATOR = ->(a) { File.exist?(a) }.freeze

--- a/lib/manageiq/appliance_console/database_admin.rb
+++ b/lib/manageiq/appliance_console/database_admin.rb
@@ -167,17 +167,16 @@ module ManageIQ
 
       def ask_swift_file_options
         require 'uri'
-        @uri              = ask_for_uri(*remote_file_prompt_args_for("swift"))
+        @uri              = URI(ask_for_uri(*remote_file_prompt_args_for("swift")))
         user              = just_ask(USER_PROMPT)
         pass              = ask_for_password("password for #{user}")
         region            = just_ask("OpenStack Swift Region")
-        port              = just_ask("OpenStack Swift Port", "5000")
+        @uri.port         = just_ask("OpenStack Swift Port", "5000")
         security_protocol = ask_with_menu(*security_protocol_menu_args)
         api_version       = ask_with_menu(*api_version_menu_args)
         domain_ident      = just_ask("OpenStack V3 Domain Identifier") if api_version == "v3"
 
         @task          = "evm:db:#{action}:remote"
-        @uri           = URI.parse("#{URI(@uri).scheme}://#{URI(@uri).host}:#{port}#{URI(@uri).path}")
         query_elements = []
         query_elements << "region=#{region}"                       if region.present?
         query_elements << "api_version=#{api_version}"             if api_version.present?

--- a/lib/manageiq/appliance_console/prompts.rb
+++ b/lib/manageiq/appliance_console/prompts.rb
@@ -28,6 +28,7 @@ module ApplianceConsole
             (u.host =~ HOSTNAME_REGEXP || u.hostname =~ IP_REGEXP) &&
             (opts[:optional_path] || !u.path.empty?)
         end
+        yield q if block_given?
       end
     end
 

--- a/locales/appliance/en.yml
+++ b/locales/appliance/en.yml
@@ -49,13 +49,16 @@ en:
     - smb
     - s3
     - ftp
+    - swift
     local: Local file
     nfs: Network File System (NFS)
     smb: Samba (SMB)
     s3: Amazon S3 (S3)
     ftp: File Transfer Protocol (FTP)
+    swift: OpenStack Swift (Swift)
     sample_url:
       nfs: nfs://host.mydomain.com/exported/my_exported_folder/db.backup
       smb: smb://host.mydomain.com/my_share/daily_backup/db.backup
       s3: s3://mybucket/my_subdirectory/daily_backup/db.backup
       ftp: ftp://host.mydomain.com/path/to/daily_backup/db.backup
+      swift: swift://host.mydomain.com/path/to/daily_backup/db.backup

--- a/spec/database_admin_spec.rb
+++ b/spec/database_admin_spec.rb
@@ -110,7 +110,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         expect(subject).to receive(:ask_swift_file_options).once
         say "6"
         subject.ask_file_location
-        expect(subject.backup_type).to eq(described_class::SWIFT_FILE)
+        expect(subject.backup_type).to eq("swift")
       end
 
       it "cancels when CANCEL option is choosen" do
@@ -1159,7 +1159,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         expect(subject).to receive(:ask_swift_file_options).once
         say "6"
         subject.ask_file_location
-        expect(subject.backup_type).to eq(described_class::SWIFT_FILE)
+        expect(subject.backup_type).to eq("swift")
       end
 
       it "cancels when CANCEL option is choosen" do
@@ -2130,7 +2130,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         expect(subject).to receive(:ask_swift_file_options).once
         say "6"
         subject.ask_file_location
-        expect(subject.backup_type).to eq(described_class::SWIFT_FILE)
+        expect(subject.backup_type).to eq("swift")
       end
       it "cancels when CANCEL option is choosen" do
         say "7"

--- a/spec/database_admin_spec.rb
+++ b/spec/database_admin_spec.rb
@@ -57,7 +57,8 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
           3) Samba (SMB)
           4) Amazon S3 (S3)
           5) File Transfer Protocol (FTP)
-          6) Cancel
+          6) OpenStack Swift (Swift)
+          7) Cancel
 
           Choose the restore database file: |1|
         PROMPT
@@ -105,8 +106,15 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         expect(subject.backup_type).to eq("ftp")
       end
 
-      it "cancels when CANCEL option is choosen" do
+      it "calls #ask_swift_file_options when choosen" do
+        expect(subject).to receive(:ask_swift_file_options).once
         say "6"
+        subject.ask_file_location
+        expect(subject.backup_type).to eq(described_class::SWIFT_FILE)
+      end
+
+      it "cancels when CANCEL option is choosen" do
+        say "7"
         expect { subject.ask_file_location }.to raise_error signal_error
       end
 
@@ -930,7 +938,8 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
           3) Samba (SMB)
           4) Amazon S3 (S3)
           5) File Transfer Protocol (FTP)
-          6) Cancel
+          6) OpenStack Swift (Swift)
+          7) Cancel
 
           Choose the backup output file name: |1|
         PROMPT
@@ -978,8 +987,15 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         expect(subject.backup_type).to eq("ftp")
       end
 
-      it "cancels when CANCEL option is choosen" do
+      it "calls #ask_swift_file_options when choosen" do
+        expect(subject).to receive(:ask_swift_file_options).once
         say "6"
+        subject.ask_file_location
+        expect(subject.backup_type).to eq(described_class::SWIFT_FILE)
+      end
+
+      it "cancels when CANCEL option is choosen" do
+        say "7"
         expect { subject.ask_file_location }.to raise_error signal_error
       end
 
@@ -1763,7 +1779,8 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
           3) Samba (SMB)
           4) Amazon S3 (S3)
           5) File Transfer Protocol (FTP)
-          6) Cancel
+          6) OpenStack Swift (Swift)
+          7) Cancel
 
           Choose the dump output file name: |1|
         PROMPT
@@ -1804,8 +1821,14 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         expect(subject.backup_type).to eq("ftp")
       end
 
-      it "cancels when CANCEL option is choosen" do
+      it "calls #ask_swift_file_options when choosen" do
+        expect(subject).to receive(:ask_swift_file_options).once
         say "6"
+        subject.ask_file_location
+        expect(subject.backup_type).to eq(described_class::SWIFT_FILE)
+      end
+      it "cancels when CANCEL option is choosen" do
+        say "7"
         expect { subject.ask_file_location }.to raise_error signal_error
       end
 

--- a/spec/database_admin_spec.rb
+++ b/spec/database_admin_spec.rb
@@ -519,91 +519,170 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       end
     end
 
-    describe "#ask_swift_file_options" do
-      let(:example_uri) { subject.send(:sample_url, 'swift') }
-      let(:uri)         { File.dirname(example_uri) }
-      let(:filename)    { File.basename(example_uri) }
-      let(:user)              { 'foobar' }
-      let(:pass)              { 'supersecret' }
-      let(:region)            { 'anyregion' }
-      let(:port)              { '5000' }
-      let(:security_protocol) { 'non-ssl' }
-      let(:api_version)       { 'v2' }
-      let(:domain_ident)      { 'default' }
-      let(:uri_prompt)        { "Enter the location of the remote backup file\nExample: #{example_uri}" }
-      let(:user_prompt)       { "Enter the User Name with access to this file.\nExample: 'openstack_user'" }
-      let(:pass_prompt)       { "Enter the password for #{user}" }
-      let(:region_prompt)     { "Enter the OpenStack Swift Region" }
-      let(:port_prompt)       { "Enter the OpenStack Swift Port" }
-      let(:domain_prompt)     { "OpenStack V3 Domain Identifier" }
-      let(:security_protocol_prompt) { "OpenStack Security Protocol\n\n1) SSL without validation\n2) SSL\n3) Non-SSL\n4)Cancel\n\nChoose the openstack security protocol: |3|" }
-      let(:api_version_prompt)       { "OpenStack API Version\n\n1) Keystone v2\n2) Keystone v3\n3) Cancel\n\nChoose the openstack api version: |1|" }
-      let(:errmsg)                   { "a valid URI" }
-
-      let(:expected_task_params) do
+    context "for Swift DB Restore" do
+      let(:example_uri)          { subject.send(:sample_url, 'swift') }
+      let(:uri)                  { URI(File.dirname(example_uri)) }
+      let(:filename)             { File.basename(example_uri) }
+      let(:user)                 { 'foobar' }
+      let(:pass)                 { 'supersecret' }
+      let(:uri_prompt)           { "Enter the location of the remote backup file\nExample: #{example_uri}: " }
+      let(:user_prompt)          { "\n?  Enter the User Name with access to this file.\nExample: 'openstack_user': " }
+      let(:pass_prompt)          { "Enter the password for #{user}" }
+      let(:region_prompt)        { "Enter the OpenStack Swift Region: " }
+      let(:port_prompt)          { "Enter the OpenStack Swift Port: |5000| " }
+      let(:domain_prompt)        { "OpenStack V3 Domain Identifier" }
+      let(:security_protocol_prompt) { "OpenStack Security Protocol\n\n1) SSL without validation\n2) SSL\n3) Non-SSL\n4) None\n\nChoose the openstack security protocol: |3| " }
+      let(:api_version_prompt)       { "OpenStack API Version\n\n1) Keystone v2\n2) Keystone v3\n3) None\n\nChoose the openstack api version: |1| " }
+      let(:errmsg)               { "a valid URI" }
+      let(:port)                 { 5000 }
+      let(:nondefaultport)       { 6789 }
+      let(:region)               { 'anyregion' }
+      let(:security_protocol)    { 'non-ssl' }
+      let(:v2_api_version)       { 'v2' }
+      let(:v3_api_version)       { 'v3' }
+      let(:domain_ident)         { 'default' }
+      let(:v2_query_string) { "region=#{region}&api_version=#{v2_api_version}&security_protocol=#{security_protocol}" }
+      let(:v2_query_elements) do
         [
-          "--",
-          {
-            :uri          => uri,
-            :uri_username => user,
-            :uri_password => pass,
-          }
+          "region=#{region}",
+          "api_version=#{v2_api_version}",
+          "security_protocol=#{security_protocol}"
+        ]
+      end
+      let(:v3_query_string) { "region=#{region}&api_version=#{v3_api_version}&domain_id=#{domain_ident}&security_protocol=#{security_protocol}" }
+      let(:v3_query_elements) do
+        [
+          "region=#{region}",
+          "api_version=#{v3_api_version}",
+          "domain_id=#{domain_ident}",
+          "security_protocol=#{security_protocol}"
         ]
       end
 
-      context "with a valid uri, user, password, and region given" do
-        before do
-          say [uri, user, region, port, security_protocol, api_version, pass]
-          expect(subject.ask_swift_file_options).to be_truthy
+      describe "#ask_swift_file_options" do
+        let(:expected_task_params) do
+          [
+            "--",
+            {
+              :uri          => uri.to_s,
+              :uri_username => user,
+              :uri_password => pass,
+            }
+          ]
         end
 
-        it "sets @uri to point to the swift share url" do
-          expect(subject.uri).to eq(uri)
+        context "with a valid uri, user, password, and default port, api, protocol given" do
+          before do
+            say [uri, user, pass, region, "", "", ""]
+            expect(subject.ask_swift_file_options).to be_truthy
+          end
+
+          it "sets @uri to point to the swift share url" do
+            uri.port  = port
+            uri.query = v2_query_string
+            expect(subject.uri).to eq(uri)
+          end
+
+          it "sets @filename to nil" do
+            expect(subject.filename).to eq(nil)
+          end
+
+          it "sets @task to point to 'evm:db:restore:remote'" do
+            expect(subject.task).to eq("evm:db:restore:remote")
+          end
+
+          it "sets @task_params to point to the swift file, user, and pass" do
+            uri.port = port
+            uri.query = v2_query_string
+            expect(subject.task_params).to eq(expected_task_params)
+          end
         end
 
-        it "sets @filename to nil" do
-          expect(subject.filename).to eq(nil)
+        context "with a valid uri, user, password, and non-default port, api, protocol given" do
+          before do
+            say [uri, user, pass, region, nondefaultport, 3, 1]
+            expect(subject.ask_swift_file_options).to be_truthy
+          end
+
+          it "sets @uri to point to the swift share url" do
+            uri.port  = nondefaultport
+            uri.query = v2_query_string
+            expect(subject.uri).to eq(uri)
+          end
+
+          it "sets @filename to nil" do
+            expect(subject.filename).to eq(nil)
+          end
+
+          it "sets @task to point to 'evm:db:restore:remote'" do
+            expect(subject.task).to eq("evm:db:restore:remote")
+          end
+
+          it "sets @task_params to point to the swift file, user, and pass" do
+            uri.port = nondefaultport
+            uri.query = v2_query_string
+            expect(subject.task_params).to eq(expected_task_params)
+          end
         end
 
-        it "sets @task to point to 'evm:db:restore:remote'" do
-          expect(subject.task).to eq("evm:db:restore:remote")
-        end
+        context "with an invalid uri given" do
+          let(:bad_uri) { "nfs://host.mydomain.com/path/to/file" }
 
-        it "sets @task_params to point to the swift file, user, and pass" do
-          expect(subject.task_params).to eq(expected_task_params)
+          before do
+            say [bad_uri, uri, user, pass, region, "", "", ""]
+            expect(subject.ask_swift_file_options).to be_truthy
+          end
+
+          it "reprompts the user and then properly sets the options" do
+            error = "Please provide #{errmsg}"
+
+            expect_readline_question_asked uri_prompt
+            expect_readline_question_asked user_prompt
+            expect_readline_question_asked pass_prompt
+            expect_readline_question_asked region_prompt
+            expect_readline_question_asked port_prompt
+            expect_readline_question_asked security_protocol_prompt
+            expect_readline_question_asked api_version_prompt
+            expect_heard [
+              uri_prompt,
+              error,
+              user_prompt,
+              "#{pass_prompt}: ***********\n",
+              region_prompt,
+              port_prompt,
+              security_protocol_prompt,
+              api_version_prompt
+            ]
+
+            uri.port = port
+            uri.query = v2_query_string
+            expect(subject.uri).to         eq(uri)
+            expect(subject.filename).to    eq(nil)
+            expect(subject.task).to        eq("evm:db:restore:remote")
+            expect(subject.task_params).to eq(expected_task_params)
+          end
         end
       end
 
-      context "with a invalid uri given" do
-        let(:bad_uri) { "nfs://host.mydomain.com/path/to/file" }
+      describe "#swift_query_elements" do
+        context "with a valid region, and default port, security protocol, and api_version given" do
+          it "sets query_string to the proper v2 default value" do
+            say [region, "", "", ""]
+            subject.uri = uri
+            expect(subject.swift_query_elements).to eq(v2_query_elements)
+          end
 
-        before do
-          # say [bad_uri, uri, user, pass, region, port, security_protocol, api_version]
-          say [bad_uri, uri, user, region, port, security_protocol, api_version]
-          expect(subject.ask_swift_file_options).to be_truthy
-        end
+          it "sets query_string to the proper v2 value when specified" do
+            say [region, "", 3, 1]
+            subject.uri = uri
+            expect(subject.swift_query_elements).to eq(v2_query_elements)
+          end
 
-        it "reprompts the user and then properly sets the options" do
-          error = "Please provide #{errmsg}"
-
-          expect_readline_question_asked uri_prompt
-          expect_readline_question_asked user_prompt
-          expect_readline_question_asked pass_prompt
-          expect_readline_question_asked region_prompt
-          expect_readline_question_asked port_prompt
-          expect_readline_question_asked security_protocol_prompt
-          expect_readline_question_asked api_version_prompt
-          expect_heard [
-            uri_prompt,
-            error,
-            prompt,
-            "#{pass_prompt}: ***********\n"
-          ]
-
-          expect(subject.uri).to         eq(uri)
-          expect(subject.filename).to    eq(nil)
-          expect(subject.task).to        eq("evm:db:restore:remote")
-          expect(subject.task_params).to eq(expected_task_params)
+          it "sets query_string to the proper v3 value when specified" do
+            say [region, "", "", 2, domain_ident]
+            subject.uri = uri
+            expect(subject.swift_query_elements).to eq(v3_query_elements)
+          end
         end
       end
     end


### PR DESCRIPTION
Ability to restore backups previous saved to Swift Object STorage.

In support of the RFE defined in BZ https://bugzilla.redhat.com/show_bug.cgi?id=1615488

Related PRs are https://github.com/ManageIQ/manageiq-ui-classic/pull/4684
https://github.com/ManageIQ/manageiq/pull/17967
https://github.com/ManageIQ/manageiq-gems-pending/pull/371
and
https://github.com/ManageIQ/manageiq-schema/pull/259.

@NickLaMuro @carbonin @roliveri please review.  Thanks.
