### PR TITLE
Update the minimum linux_admin version

### DIFF
--- a/manageiq-appliance_console.gemspec
+++ b/manageiq-appliance_console.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "bcrypt",                  "~> 3.1.10"
   spec.add_runtime_dependency "highline",                "~> 1.6.21"
   spec.add_runtime_dependency "i18n",                    "~> 0.7"
-  spec.add_runtime_dependency "linux_admin",             "~> 1.0"
+  spec.add_runtime_dependency "linux_admin",             ["~> 1.0", ">=1.2.2"]
   spec.add_runtime_dependency "pg"
   spec.add_runtime_dependency "trollop",                 "~> 2.0"
 


### PR DESCRIPTION
This will include the fix for detecting disk devices for use when
creating the local database

https://bugzilla.redhat.com/show_bug.cgi?id=1629853