### PR TITLE
Anonymous FTP request single file prompt (vs 2)

### DIFF
--- a/lib/manageiq/appliance_console/database_admin.rb
+++ b/lib/manageiq/appliance_console/database_admin.rb
@@ -6,12 +6,6 @@ module ManageIQ
     class DatabaseAdmin < HighLine
       include ManageIQ::ApplianceConsole::Prompts
 
-      LOCAL_FILE = "local".freeze
-      NFS_FILE   = "nfs".freeze
-      SMB_FILE   = "smb".freeze
-      S3_FILE    = "s3".freeze
-      FTP_FILE   = "ftp".freeze
-
       DB_RESTORE_FILE      = "/tmp/evm_db.backup".freeze
       DB_DEFAULT_DUMP_FILE = "/tmp/evm_db.dump".freeze
       LOCAL_FILE_VALIDATOR = ->(a) { File.exist?(a) }.freeze
@@ -36,6 +30,10 @@ module ManageIQ
 
         @action      = action
         @task_params = []
+      end
+
+      def local_backup?
+        backup_type == "local".freeze
       end
 
       def ask_questions
@@ -155,7 +153,7 @@ module ManageIQ
       end
 
       def ask_to_delete_backup_after_restore
-        if action == :restore && backup_type == LOCAL_FILE
+        if action == :restore && local_backup?
           say("The local database restore file is located at: '#{uri}'.\n")
           @delete_agree = agree("Should this file be deleted after completing the restore? (Y/N): ")
         end
@@ -218,7 +216,7 @@ module ManageIQ
         [
           action == :restore ? "Restore Database File" : "#{action.capitalize} Output File Name",
           file_options,
-          LOCAL_FILE,
+          "local",
           nil
         ]
       end
@@ -252,7 +250,7 @@ module ManageIQ
 
       def filename_prompt_args
         default   = action == :dump ? DB_DEFAULT_DUMP_FILE : DB_RESTORE_FILE
-        validator = LOCAL_FILE_VALIDATOR if action == :restore && backup_type == LOCAL_FILE
+        validator = LOCAL_FILE_VALIDATOR if action == :restore && local_backup?
         [local_file_prompt, default, validator, "file that exists"]
       end
 

--- a/lib/manageiq/appliance_console/database_admin.rb
+++ b/lib/manageiq/appliance_console/database_admin.rb
@@ -142,11 +142,11 @@ module ManageIQ
         @filename = ask_custom_file_prompt(hostname)
         @uri      = server_uri
 
-        params = {
-          :uri              => uri,
-          :skip_directory   => true,
-          :remote_file_name => filename
-        }
+        params = {:uri => uri, :remote_file_name => filename}
+
+        if (custom_params = custom_endpoint_config_for(hostname))
+          params.merge!(custom_params[:rake_options]) if custom_params[:rake_options]
+        end
 
         @task        = "evm:db:#{action}:remote"
         @task_params = ["--", params]

--- a/lib/manageiq/appliance_console/database_admin.rb
+++ b/lib/manageiq/appliance_console/database_admin.rb
@@ -141,7 +141,7 @@ module ManageIQ
 
       def ask_custom_file_options(server_uri)
         hostname  = URI(server_uri).host
-        @filename = ask_custom_prompt(hostname, 'filename', "Target filename for backup")
+        @filename = ask_custom_file_prompt(hostname)
         @uri      = server_uri
 
         params = {
@@ -229,11 +229,11 @@ module ManageIQ
 
       private
 
-      def ask_custom_prompt(type, prompt_name, default_prompt)
-        # type (domain name) has a period in it, so we need to look it up by [] instead of the traditional i18n method
-        prompts = I18n.t("database_admin.prompts", :default => {})[type.to_sym]
-        prompt_text  = prompts && prompts["#{prompt_name}_text".to_sym] || default_prompt
-        prompt_regex = prompts && prompts["#{prompt_name}_validator".to_sym]
+      def ask_custom_file_prompt(hostname)
+        # hostname has a period in it, so we need to look it up by [] instead of the traditional i18n method
+        prompts = I18n.t("database_admin.prompts", :default => {})[hostname.to_sym]
+        prompt_text  = prompts && prompts[:filename_text] || "Target filename for backup".freeze
+        prompt_regex = prompts && prompts[:filename_validator]
         validator    = prompt_regex ? ->(x) { x.to_s =~ /#{prompt_regex}/ } : ->(x) { x.to_s.present? }
         just_ask(prompt_text, nil, validator)
       end

--- a/spec/database_admin_spec.rb
+++ b/spec/database_admin_spec.rb
@@ -110,10 +110,12 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         expect { subject.ask_file_location }.to raise_error signal_error
       end
 
+      # this is the complete implementation. the other 2 are paired down version of this
       context "with localized file upload" do
-        it "displays custom ftp option" do
+        it "displays custom ftp option with no prompts" do
           expect(I18n).to receive(:t).with("database_admin.menu_order").and_return(%w(local ftp://example.com/inbox/filename.txt))
           expect(I18n).to receive(:t).with("database_admin.local").and_return("The Local file")
+          expect(I18n).to receive(:t).with("database_admin.prompts", :default=>{}).and_return({})
           expect(subject).to receive(:ask_local_file_options).once
           say ""
           subject.ask_file_location
@@ -123,6 +125,112 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
             1) The Local file
             2) ftp to example.com
             3) Cancel
+
+            Choose the restore database file: |1|
+          PROMPT
+        end
+
+        it "displays custom ftp option with other prompts" do
+          expect(I18n).to receive(:t).with("database_admin.menu_order").and_return(%w(local ftp://example.com/inbox/filename.txt))
+          expect(I18n).to receive(:t).with("database_admin.local").and_return("The Local file")
+          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).and_return(:"example.com" => { :filename_text => "" })
+          expect(subject).to receive(:ask_local_file_options).once
+          say ""
+          subject.ask_file_location
+          expect_output <<-PROMPT.strip_heredoc.chomp + " "
+            Restore Database File
+
+            1) The Local file
+            2) ftp to example.com
+            3) Cancel
+
+            Choose the restore database file: |1|
+          PROMPT
+        end
+
+        it "displays custom ftp option with enabled blank" do
+          expect(I18n).to receive(:t).with("database_admin.menu_order").and_return(%w(local ftp://example.com/inbox/filename.txt))
+          expect(I18n).to receive(:t).with("database_admin.local").and_return("The Local file")
+          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).and_return(:"example.com" => { :enabled_for => "" })
+          expect(subject).to receive(:ask_local_file_options).once
+          say ""
+          subject.ask_file_location
+          expect_output <<-PROMPT.strip_heredoc.chomp + " "
+            Restore Database File
+
+            1) The Local file
+            2) ftp to example.com
+            3) Cancel
+
+            Choose the restore database file: |1|
+          PROMPT
+        end
+
+        it "displays custom ftp option with enabled string" do
+          expect(I18n).to receive(:t).with("database_admin.menu_order").and_return(%w(local ftp://example.com/inbox/filename.txt))
+          expect(I18n).to receive(:t).with("database_admin.local").and_return("The Local file")
+          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).and_return(:"example.com" => { :enabled_for => "restore" })
+          expect(subject).to receive(:ask_local_file_options).once
+          say ""
+          subject.ask_file_location
+          expect_output <<-PROMPT.strip_heredoc.chomp + " "
+            Restore Database File
+
+            1) The Local file
+            2) ftp to example.com
+            3) Cancel
+
+            Choose the restore database file: |1|
+          PROMPT
+        end
+
+        it "displays custom ftp option with enabled array" do
+          expect(I18n).to receive(:t).with("database_admin.menu_order").and_return(%w(local ftp://example.com/inbox/filename.txt))
+          expect(I18n).to receive(:t).with("database_admin.local").and_return("The Local file")
+          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).and_return(:"example.com" => { :enabled_for => %w(restore backup) })
+          expect(subject).to receive(:ask_local_file_options).once
+          say ""
+          subject.ask_file_location
+          expect_output <<-PROMPT.strip_heredoc.chomp + " "
+            Restore Database File
+
+            1) The Local file
+            2) ftp to example.com
+            3) Cancel
+
+            Choose the restore database file: |1|
+          PROMPT
+        end
+
+        it "hides custom ftp option with other string prompts" do
+          expect(I18n).to receive(:t).with("database_admin.menu_order").and_return(%w(local ftp://example.com/inbox/filename.txt))
+          expect(I18n).to receive(:t).with("database_admin.local").and_return("The Local file")
+          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).and_return(:"example.com" => { :enabled_for => "backup" })
+          expect(subject).to receive(:ask_local_file_options).once
+          say ""
+          subject.ask_file_location
+          expect_output <<-PROMPT.strip_heredoc.chomp + " "
+            Restore Database File
+
+            1) The Local file
+            2) Cancel
+
+            Choose the restore database file: |1|
+          PROMPT
+        end
+
+        it "hides custom ftp option with other array prompts" do
+          expect(I18n).to receive(:t).with("database_admin.menu_order").and_return(%w(local ftp://example.com/inbox/filename.txt))
+          expect(I18n).to receive(:t).with("database_admin.local").and_return("The Local file")
+          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).and_return(:"example.com" => { :enabled_for => %w(backup dump) })
+          expect(subject).to receive(:ask_local_file_options).once
+          say ""
+          subject.ask_file_location
+          expect_output <<-PROMPT.strip_heredoc.chomp + " "
+            Restore Database File
+
+            1) The Local file
+            2) Cancel
 
             Choose the restore database file: |1|
           PROMPT
@@ -891,9 +999,10 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       end
 
       context "with localized file upload" do
-        it "displays custom ftp option" do
+        it "displays custom ftp option with blank prompts" do
           expect(I18n).to receive(:t).with("database_admin.menu_order").and_return(%w(local ftp://example.com/inbox/filename.txt))
           expect(I18n).to receive(:t).with("database_admin.local").and_return("The Local file")
+          expect(I18n).to receive(:t).with("database_admin.prompts", :default=>{}).and_return({})
           expect(subject).to receive(:ask_local_file_options).once
           say ""
           subject.ask_file_location
@@ -903,6 +1012,41 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
             1) The Local file
             2) ftp to example.com
             3) Cancel
+
+            Choose the backup output file name: |1|
+          PROMPT
+        end
+
+        it "displays custom ftp option with enabled array" do
+          expect(I18n).to receive(:t).with("database_admin.menu_order").and_return(%w(local ftp://example.com/inbox/filename.txt))
+          expect(I18n).to receive(:t).with("database_admin.local").and_return("The Local file")
+          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).and_return(:"example.com" => { :enabled_for => %w(restore backup) })
+          expect(subject).to receive(:ask_local_file_options).once
+          say ""
+          subject.ask_file_location
+          expect_output <<-PROMPT.strip_heredoc.chomp + " "
+            Backup Output File Name
+
+            1) The Local file
+            2) ftp to example.com
+            3) Cancel
+
+            Choose the backup output file name: |1|
+          PROMPT
+        end
+
+        it "hids custom ftp option with disabled string" do
+          expect(I18n).to receive(:t).with("database_admin.menu_order").and_return(%w(local ftp://example.com/inbox/filename.txt))
+          expect(I18n).to receive(:t).with("database_admin.local").and_return("The Local file")
+          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).and_return(:"example.com" => { :enabled_for => "dump" })
+          expect(subject).to receive(:ask_local_file_options).once
+          say ""
+          subject.ask_file_location
+          expect_output <<-PROMPT.strip_heredoc.chomp + " "
+            Backup Output File Name
+
+            1) The Local file
+            2) Cancel
 
             Choose the backup output file name: |1|
           PROMPT
@@ -1656,9 +1800,10 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       end
 
       context "with localized file upload" do
-        it "displays custom ftp option" do
+        it "displays custom ftp option with blank prompts" do
           expect(I18n).to receive(:t).with("database_admin.menu_order").and_return(%w(local ftp://example.com/inbox/filename.txt))
           expect(I18n).to receive(:t).with("database_admin.local").and_return("The Local file")
+          expect(I18n).to receive(:t).with("database_admin.prompts", :default=>{}).and_return({})
           expect(subject).to receive(:ask_local_file_options).once
           say ""
           subject.ask_file_location
@@ -1668,6 +1813,41 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
             1) The Local file
             2) ftp to example.com
             3) Cancel
+
+            Choose the dump output file name: |1|
+          PROMPT
+        end
+
+        it "displays custom ftp option with enabled array" do
+          expect(I18n).to receive(:t).with("database_admin.menu_order").and_return(%w(local ftp://example.com/inbox/filename.txt))
+          expect(I18n).to receive(:t).with("database_admin.local").and_return("The Local file")
+          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).and_return(:"example.com" => { :enabled_for => %w(dump backup) })
+          expect(subject).to receive(:ask_local_file_options).once
+          say ""
+          subject.ask_file_location
+          expect_output <<-PROMPT.strip_heredoc.chomp + " "
+            Dump Output File Name
+
+            1) The Local file
+            2) ftp to example.com
+            3) Cancel
+
+            Choose the dump output file name: |1|
+          PROMPT
+        end
+
+        it "hides custom ftp option with other string prompts" do
+          expect(I18n).to receive(:t).with("database_admin.menu_order").and_return(%w(local ftp://example.com/inbox/filename.txt))
+          expect(I18n).to receive(:t).with("database_admin.local").and_return("The Local file")
+          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).and_return(:"example.com" => { :enabled_for => "backup" })
+          expect(subject).to receive(:ask_local_file_options).once
+          say ""
+          subject.ask_file_location
+          expect_output <<-PROMPT.strip_heredoc.chomp + " "
+            Dump Output File Name
+
+            1) The Local file
+            2) Cancel
 
             Choose the dump output file name: |1|
           PROMPT

--- a/spec/database_admin_spec.rb
+++ b/spec/database_admin_spec.rb
@@ -621,7 +621,6 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
           {
             :uri              => example_uri,
             :remote_file_name => target,
-            :skip_directory   => true
           }
         ]
       end
@@ -662,7 +661,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
 
       context "with custom prompts" do
         before do
-          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).and_return(
+          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).twice.and_return(
             host.to_sym => {
               :filename_text      => "Target please",
               :filename_validator => "^[0-9]+-.+$"
@@ -1447,7 +1446,6 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
           {
             :uri              => example_uri,
             :remote_file_name => target,
-            :skip_directory   => true
           }
         ]
       end
@@ -1488,7 +1486,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
 
       context "with custom prompts" do
         before do
-          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).and_return(
+          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).twice.and_return(
             host.to_sym => {
               :filename_text      => "Target please",
               :filename_validator => "^[0-9]+-.+$"
@@ -1507,6 +1505,41 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         end
 
         it "uses custom validation" do
+          expect(subject.task_params).to eq(expected_task_params)
+        end
+      end
+      context "with custom prompts and rake_options" do
+        let(:expected_task_params) do
+          [
+            "--",
+            {
+              :uri              => example_uri,
+              :remote_file_name => target,
+              :skip_directory   => true,
+            }
+          ]
+        end
+        before do
+          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).at_least(:once).and_return(
+            host.to_sym => {
+              :filename_text      => "Target please",
+              :filename_validator => "^[0-9]+-.+$",
+              :rake_options       => { :skip_directory => true },
+            }
+          )
+
+          # if it doesn't ask again, it won't get the right task_params
+          say ["", "bad-2", target]
+          expect(subject.ask_custom_file_options(example_uri)).to be_truthy
+          expect_readline_question_asked "Target please: "
+          expect_output [
+            "Please provide in the specified format",
+            "?  Please provide in the specified format",
+            "?  ",
+          ].join("\n")
+        end
+
+        it "produces expected parameters" do
           expect(subject.task_params).to eq(expected_task_params)
         end
       end
@@ -2116,7 +2149,6 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
           {
             :uri              => example_uri,
             :remote_file_name => target,
-            :skip_directory   => true
           }
         ]
       end
@@ -2157,7 +2189,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
 
       context "with custom prompts" do
         before do
-          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).and_return(
+          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).twice.and_return(
             host.to_sym => {
               :filename_text      => "Target please",
               :filename_validator => "^[0-9]+-.+$"

--- a/spec/database_admin_spec.rb
+++ b/spec/database_admin_spec.rb
@@ -109,6 +109,25 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         say "6"
         expect { subject.ask_file_location }.to raise_error signal_error
       end
+
+      context "with localized file upload" do
+        it "displays custom ftp option" do
+          expect(I18n).to receive(:t).with("database_admin.menu_order").and_return(%w(local ftp://example.com/inbox/filename.txt))
+          expect(I18n).to receive(:t).with("database_admin.local").and_return("The Local file")
+          expect(subject).to receive(:ask_local_file_options).once
+          say ""
+          subject.ask_file_location
+          expect_output <<-PROMPT.strip_heredoc.chomp + " "
+            Restore Database File
+
+            1) The Local file
+            2) ftp to example.com
+            3) Cancel
+
+            Choose the restore database file: |1|
+          PROMPT
+        end
+      end
     end
 
     describe "#ask_local_file_options" do
@@ -483,6 +502,82 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       end
     end
 
+    describe "#ask_custom_file_options" do
+      let(:example_uri) { "ftp://example.com/inbox/" }
+      let(:host)        { URI(example_uri).host }
+      let(:target)      { "123456-filename.txt" }
+
+      let(:expected_task_params) do
+        [
+          "--",
+          {
+            :uri              => example_uri,
+            :remote_file_name => target,
+            :skip_directory   => true
+          }
+        ]
+      end
+
+      context "with a valid target" do
+        before do
+          say [target]
+          expect(subject.ask_custom_file_options(example_uri)).to be_truthy
+        end
+
+        it "sets @uri to point to the ftp share url" do
+          expect(subject.uri).to eq(example_uri)
+        end
+
+        it "sets @filename to nil" do
+          expect(subject.filename).to eq(target)
+        end
+
+        it "sets @task to point to 'evm:db:restore:remote'" do
+          expect(subject.task).to eq("evm:db:restore:remote")
+        end
+
+        it "sets @task_params to point to the ftp file" do
+          expect(subject.task_params).to eq(expected_task_params)
+        end
+      end
+
+      context "with invalid target (then valid)" do
+        before do
+          say ["", target]
+          expect(subject.ask_custom_file_options(example_uri)).to be_truthy
+        end
+
+        it "sets @task_params to point to the ftp file" do
+          expect(subject.task_params).to eq(expected_task_params)
+        end
+      end
+
+      context "with custom prompts" do
+        before do
+          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).and_return(
+            host.to_sym => {
+              :filename_text      => "Target please",
+              :filename_validator => "^[0-9]+-.+$"
+            }
+          )
+
+          # if it doesn't ask again, it won't get the right task_params
+          say ["", "bad-2", target]
+          expect(subject.ask_custom_file_options(example_uri)).to be_truthy
+          expect_readline_question_asked "Target please: "
+          expect_output [
+            "Please provide in the specified format",
+            "?  Please provide in the specified format",
+            "?  ",
+          ].join("\n")
+        end
+
+        it "uses custom validation" do
+          expect(subject.task_params).to eq(expected_task_params)
+        end
+      end
+    end
+
     describe "#ask_to_delete_backup_after_restore" do
       context "when @backup_type is LOCAL_FILE" do
         let(:uri) { described_class::DB_RESTORE_FILE }
@@ -793,6 +888,25 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       it "cancels when CANCEL option is choosen" do
         say "6"
         expect { subject.ask_file_location }.to raise_error signal_error
+      end
+
+      context "with localized file upload" do
+        it "displays custom ftp option" do
+          expect(I18n).to receive(:t).with("database_admin.menu_order").and_return(%w(local ftp://example.com/inbox/filename.txt))
+          expect(I18n).to receive(:t).with("database_admin.local").and_return("The Local file")
+          expect(subject).to receive(:ask_local_file_options).once
+          say ""
+          subject.ask_file_location
+          expect_output <<-PROMPT.strip_heredoc.chomp + " "
+            Backup Output File Name
+
+            1) The Local file
+            2) ftp to example.com
+            3) Cancel
+
+            Choose the backup output file name: |1|
+          PROMPT
+        end
       end
     end
 
@@ -1174,6 +1288,82 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
           expect(subject.filename).to    eq(filename)
           expect(subject.task).to        eq("evm:db:backup:remote")
           expect(subject.task_params).to eq(task_params_expected)
+        end
+      end
+    end
+
+    describe "#ask_custom_file_options" do
+      let(:example_uri) { "ftp://example.com/inbox/" }
+      let(:host)        { URI(example_uri).host }
+      let(:target)      { "123456-filename.txt" }
+
+      let(:expected_task_params) do
+        [
+          "--",
+          {
+            :uri              => example_uri,
+            :remote_file_name => target,
+            :skip_directory   => true
+          }
+        ]
+      end
+
+      context "with a valid target" do
+        before do
+          say [target]
+          expect(subject.ask_custom_file_options(example_uri)).to be_truthy
+        end
+
+        it "sets @uri to point to the ftp share url" do
+          expect(subject.uri).to eq(example_uri)
+        end
+
+        it "sets @filename to nil" do
+          expect(subject.filename).to eq(target)
+        end
+
+        it "sets @task to point to 'evm:db:backup:remote'" do
+          expect(subject.task).to eq("evm:db:backup:remote")
+        end
+
+        it "sets @task_params to point to the ftp file" do
+          expect(subject.task_params).to eq(expected_task_params)
+        end
+      end
+
+      context "with invalid target (then valid)" do
+        before do
+          say ["", target]
+          expect(subject.ask_custom_file_options(example_uri)).to be_truthy
+        end
+
+        it "sets @task_params to point to the ftp file" do
+          expect(subject.task_params).to eq(expected_task_params)
+        end
+      end
+
+      context "with custom prompts" do
+        before do
+          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).and_return(
+            host.to_sym => {
+              :filename_text      => "Target please",
+              :filename_validator => "^[0-9]+-.+$"
+            }
+          )
+
+          # if it doesn't ask again, it won't get the right task_params
+          say ["", "bad-2", target]
+          expect(subject.ask_custom_file_options(example_uri)).to be_truthy
+          expect_readline_question_asked "Target please: "
+          expect_output [
+            "Please provide in the specified format",
+            "?  Please provide in the specified format",
+            "?  ",
+          ].join("\n")
+        end
+
+        it "uses custom validation" do
+          expect(subject.task_params).to eq(expected_task_params)
         end
       end
     end

--- a/spec/database_admin_spec.rb
+++ b/spec/database_admin_spec.rb
@@ -67,42 +67,42 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         expect(subject).to receive(:ask_local_file_options).once
         say ""
         subject.ask_file_location
-        expect(subject.backup_type).to eq(described_class::LOCAL_FILE)
+        expect(subject.backup_type).to eq("local")
       end
 
       it "calls #ask_local_file_options when choosen" do
         expect(subject).to receive(:ask_local_file_options).once
         say "1"
         subject.ask_file_location
-        expect(subject.backup_type).to eq(described_class::LOCAL_FILE)
+        expect(subject.backup_type).to eq("local")
       end
 
       it "calls #ask_nfs_file_options when choosen" do
         expect(subject).to receive(:ask_nfs_file_options).once
         say "2"
         subject.ask_file_location
-        expect(subject.backup_type).to eq(described_class::NFS_FILE)
+        expect(subject.backup_type).to eq("nfs")
       end
 
       it "calls #ask_smb_file_options when choosen" do
         expect(subject).to receive(:ask_smb_file_options).once
         say "3"
         subject.ask_file_location
-        expect(subject.backup_type).to eq(described_class::SMB_FILE)
+        expect(subject.backup_type).to eq("smb")
       end
 
       it "calls #ask_s3_file_options when choosen" do
         expect(subject).to receive(:ask_s3_file_options).once
         say "4"
         subject.ask_file_location
-        expect(subject.backup_type).to eq(described_class::S3_FILE)
+        expect(subject.backup_type).to eq("s3")
       end
 
       it "calls #ask_ftp_file_options when choosen" do
         expect(subject).to receive(:ask_ftp_file_options).once
         say "5"
         subject.ask_file_location
-        expect(subject.backup_type).to eq(described_class::FTP_FILE)
+        expect(subject.backup_type).to eq("ftp")
       end
 
       it "cancels when CANCEL option is choosen" do
@@ -136,7 +136,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       let(:default)   { described_class::DB_RESTORE_FILE }
       let(:errmsg)    { "file that exists" }
 
-      before { subject.instance_variable_set(:@backup_type, described_class::LOCAL_FILE) }
+      before { subject.instance_variable_set(:@backup_type, "local") }
 
       context "with no filename given" do
         before do
@@ -584,7 +584,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
 
         before do
           subject.instance_variable_set(:@uri, uri)
-          subject.instance_variable_set(:@backup_type, described_class::LOCAL_FILE)
+          subject.instance_variable_set(:@backup_type, "local")
         end
 
         it "sets @delete_agree if the user agrees" do
@@ -614,7 +614,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
 
         before do
           subject.instance_variable_set(:@uri, uri)
-          subject.instance_variable_set(:@backup_type, described_class::NFS_FILE)
+          subject.instance_variable_set(:@backup_type, "nfs")
         end
 
         it "no-ops" do
@@ -847,42 +847,42 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         expect(subject).to receive(:ask_local_file_options).once
         say ""
         subject.ask_file_location
-        expect(subject.backup_type).to eq(described_class::LOCAL_FILE)
+        expect(subject.backup_type).to eq("local")
       end
 
       it "calls #ask_local_file_options when choosen" do
         expect(subject).to receive(:ask_local_file_options).once
         say "1"
         subject.ask_file_location
-        expect(subject.backup_type).to eq(described_class::LOCAL_FILE)
+        expect(subject.backup_type).to eq("local")
       end
 
       it "calls #ask_nfs_file_options when choosen" do
         expect(subject).to receive(:ask_nfs_file_options).once
         say "2"
         subject.ask_file_location
-        expect(subject.backup_type).to eq(described_class::NFS_FILE)
+        expect(subject.backup_type).to eq("nfs")
       end
 
       it "calls #ask_smb_file_options when choosen" do
         expect(subject).to receive(:ask_smb_file_options).once
         say "3"
         subject.ask_file_location
-        expect(subject.backup_type).to eq(described_class::SMB_FILE)
+        expect(subject.backup_type).to eq("smb")
       end
 
       it "calls #ask_s3_file_options when choosen" do
         expect(subject).to receive(:ask_s3_file_options).once
         say "4"
         subject.ask_file_location
-        expect(subject.backup_type).to eq(described_class::S3_FILE)
+        expect(subject.backup_type).to eq("s3")
       end
 
       it "calls #ask_ftp_file_options when choosen" do
         expect(subject).to receive(:ask_ftp_file_options).once
         say "5"
         subject.ask_file_location
-        expect(subject.backup_type).to eq(described_class::FTP_FILE)
+        expect(subject.backup_type).to eq("ftp")
       end
 
       it "cancels when CANCEL option is choosen" do
@@ -1374,7 +1374,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
 
         before do
           subject.instance_variable_set(:@uri, uri)
-          subject.instance_variable_set(:@backup_type, described_class::LOCAL_FILE)
+          subject.instance_variable_set(:@backup_type, "local")
         end
 
         it "no-ops" do
@@ -1388,7 +1388,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
 
         before do
           subject.instance_variable_set(:@uri, uri)
-          subject.instance_variable_set(:@backup_type, described_class::NFS_FILE)
+          subject.instance_variable_set(:@backup_type, "nfs")
         end
 
         it "no-ops" do
@@ -1619,35 +1619,35 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         expect(subject).to receive(:ask_local_file_options).once
         say ""
         subject.ask_file_location
-        expect(subject.backup_type).to eq(described_class::LOCAL_FILE)
+        expect(subject.backup_type).to eq("local")
       end
 
       it "calls #ask_local_file_options when choosen" do
         expect(subject).to receive(:ask_local_file_options).once
         say "1"
         subject.ask_file_location
-        expect(subject.backup_type).to eq(described_class::LOCAL_FILE)
+        expect(subject.backup_type).to eq("local")
       end
 
       it "calls #ask_nfs_file_options when choosen" do
         expect(subject).to receive(:ask_nfs_file_options).once
         say "2"
         subject.ask_file_location
-        expect(subject.backup_type).to eq(described_class::NFS_FILE)
+        expect(subject.backup_type).to eq("nfs")
       end
 
       it "calls #ask_smb_file_options when choosen" do
         expect(subject).to receive(:ask_smb_file_options).once
         say "3"
         subject.ask_file_location
-        expect(subject.backup_type).to eq(described_class::SMB_FILE)
+        expect(subject.backup_type).to eq("smb")
       end
 
       it "calls #ask_ftp_file_options when choosen" do
         expect(subject).to receive(:ask_ftp_file_options).once
         say "5"
         subject.ask_file_location
-        expect(subject.backup_type).to eq(described_class::FTP_FILE)
+        expect(subject.backup_type).to eq("ftp")
       end
 
       it "cancels when CANCEL option is choosen" do
@@ -2007,7 +2007,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
 
         before do
           subject.instance_variable_set(:@uri, uri)
-          subject.instance_variable_set(:@backup_type, described_class::LOCAL_FILE)
+          subject.instance_variable_set(:@backup_type, "local")
         end
 
         it "no-ops" do
@@ -2021,7 +2021,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
 
         before do
           subject.instance_variable_set(:@uri, uri)
-          subject.instance_variable_set(:@backup_type, described_class::NFS_FILE)
+          subject.instance_variable_set(:@backup_type, "nfs")
         end
 
         it "no-ops" do
@@ -2250,5 +2250,18 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       expect(subject.send(:sample_url, 'smb')).to match(%r{smb://})
     end
   end
+  # rubocop:enable Layout/TrailingWhitespace
+
+  describe "#local_backup?" do
+    it "detects true" do
+      subject.instance_variable_set(:@backup_type, "local")
+      expect(subject).to be_local_backup
+    end
+
+    it "detects false" do
+      expect(subject).not_to be_local_backup
+      subject.instance_variable_set(:@backup_type, "ftp")
+      expect(subject).not_to be_local_backup
+    end
+  end
 end
-# rubocop:enable Layout/TrailingWhitespace

--- a/spec/database_admin_spec.rb
+++ b/spec/database_admin_spec.rb
@@ -111,10 +111,13 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       end
 
       # this is the complete implementation. the other 2 are paired down version of this
-      context "with localized file upload" do
-        it "displays custom ftp option with no prompts" do
+      context "with custom menu config" do
+        before do
           expect(I18n).to receive(:t).with("database_admin.menu_order").and_return(%w(local ftp://example.com/inbox/filename.txt))
           expect(I18n).to receive(:t).with("database_admin.local").and_return("The Local file")
+        end
+
+        it "displays custom ftp option with no prompts" do
           expect(I18n).to receive(:t).with("database_admin.prompts", :default=>{}).and_return({})
           expect(subject).to receive(:ask_local_file_options).once
           say ""
@@ -131,9 +134,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         end
 
         it "displays custom ftp option with other prompts" do
-          expect(I18n).to receive(:t).with("database_admin.menu_order").and_return(%w(local ftp://example.com/inbox/filename.txt))
-          expect(I18n).to receive(:t).with("database_admin.local").and_return("The Local file")
-          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).and_return(:"example.com" => { :filename_text => "" })
+          expect_custom_prompts("example.com", :filename_text => "")
           expect(subject).to receive(:ask_local_file_options).once
           say ""
           subject.ask_file_location
@@ -149,9 +150,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         end
 
         it "displays custom ftp option with enabled blank" do
-          expect(I18n).to receive(:t).with("database_admin.menu_order").and_return(%w(local ftp://example.com/inbox/filename.txt))
-          expect(I18n).to receive(:t).with("database_admin.local").and_return("The Local file")
-          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).and_return(:"example.com" => { :enabled_for => "" })
+          expect_custom_prompts("example.com", :enabled_for => "")
           expect(subject).to receive(:ask_local_file_options).once
           say ""
           subject.ask_file_location
@@ -167,9 +166,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         end
 
         it "displays custom ftp option with enabled string" do
-          expect(I18n).to receive(:t).with("database_admin.menu_order").and_return(%w(local ftp://example.com/inbox/filename.txt))
-          expect(I18n).to receive(:t).with("database_admin.local").and_return("The Local file")
-          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).and_return(:"example.com" => { :enabled_for => "restore" })
+          expect_custom_prompts("example.com", :enabled_for => "restore")
           expect(subject).to receive(:ask_local_file_options).once
           say ""
           subject.ask_file_location
@@ -185,9 +182,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         end
 
         it "displays custom ftp option with enabled array" do
-          expect(I18n).to receive(:t).with("database_admin.menu_order").and_return(%w(local ftp://example.com/inbox/filename.txt))
-          expect(I18n).to receive(:t).with("database_admin.local").and_return("The Local file")
-          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).and_return(:"example.com" => { :enabled_for => %w(restore backup) })
+          expect_custom_prompts("example.com", :enabled_for => %w(restore backup))
           expect(subject).to receive(:ask_local_file_options).once
           say ""
           subject.ask_file_location
@@ -203,9 +198,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         end
 
         it "hides custom ftp option with other string prompts" do
-          expect(I18n).to receive(:t).with("database_admin.menu_order").and_return(%w(local ftp://example.com/inbox/filename.txt))
-          expect(I18n).to receive(:t).with("database_admin.local").and_return("The Local file")
-          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).and_return(:"example.com" => { :enabled_for => "backup" })
+          expect_custom_prompts("example.com", :enabled_for => "backup")
           expect(subject).to receive(:ask_local_file_options).once
           say ""
           subject.ask_file_location
@@ -220,9 +213,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         end
 
         it "hides custom ftp option with other array prompts" do
-          expect(I18n).to receive(:t).with("database_admin.menu_order").and_return(%w(local ftp://example.com/inbox/filename.txt))
-          expect(I18n).to receive(:t).with("database_admin.local").and_return("The Local file")
-          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).and_return(:"example.com" => { :enabled_for => %w(backup dump) })
+          expect_custom_prompts("example.com", :enabled_for => %w(backup dump))
           expect(subject).to receive(:ask_local_file_options).once
           say ""
           subject.ask_file_location
@@ -661,12 +652,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
 
       context "with custom prompts" do
         before do
-          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).twice.and_return(
-            host.to_sym => {
-              :filename_text      => "Target please",
-              :filename_validator => "^[0-9]+-.+$"
-            }
-          )
+          expect_custom_prompts(host, :filename_text => "Target please", :filename_validator => "^[0-9]+-.+$").twice
 
           # if it doesn't ask again, it won't get the right task_params
           say ["", "bad-2", target]
@@ -997,10 +983,13 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         expect { subject.ask_file_location }.to raise_error signal_error
       end
 
-      context "with localized file upload" do
-        it "displays custom ftp option with blank prompts" do
+      context "with custom menu config" do
+        before do
           expect(I18n).to receive(:t).with("database_admin.menu_order").and_return(%w(local ftp://example.com/inbox/filename.txt))
           expect(I18n).to receive(:t).with("database_admin.local").and_return("The Local file")
+        end
+
+        it "displays custom ftp option with blank prompts" do
           expect(I18n).to receive(:t).with("database_admin.prompts", :default=>{}).and_return({})
           expect(subject).to receive(:ask_local_file_options).once
           say ""
@@ -1017,9 +1006,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         end
 
         it "displays custom ftp option with enabled array" do
-          expect(I18n).to receive(:t).with("database_admin.menu_order").and_return(%w(local ftp://example.com/inbox/filename.txt))
-          expect(I18n).to receive(:t).with("database_admin.local").and_return("The Local file")
-          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).and_return(:"example.com" => { :enabled_for => %w(restore backup) })
+          expect_custom_prompts("example.com", :enabled_for => %w(restore backup))
           expect(subject).to receive(:ask_local_file_options).once
           say ""
           subject.ask_file_location
@@ -1034,10 +1021,8 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
           PROMPT
         end
 
-        it "hids custom ftp option with disabled string" do
-          expect(I18n).to receive(:t).with("database_admin.menu_order").and_return(%w(local ftp://example.com/inbox/filename.txt))
-          expect(I18n).to receive(:t).with("database_admin.local").and_return("The Local file")
-          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).and_return(:"example.com" => { :enabled_for => "dump" })
+        it "hides custom ftp option with disabled string" do
+          expect_custom_prompts("example.com", :enabled_for => "dump")
           expect(subject).to receive(:ask_local_file_options).once
           say ""
           subject.ask_file_location
@@ -1486,12 +1471,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
 
       context "with custom prompts" do
         before do
-          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).twice.and_return(
-            host.to_sym => {
-              :filename_text      => "Target please",
-              :filename_validator => "^[0-9]+-.+$"
-            }
-          )
+          expect_custom_prompts(host, :filename_text => "Target please", :filename_validator => "^[0-9]+-.+$").twice
 
           # if it doesn't ask again, it won't get the right task_params
           say ["", "bad-2", target]
@@ -1520,13 +1500,10 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
           ]
         end
         before do
-          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).at_least(:once).and_return(
-            host.to_sym => {
-              :filename_text      => "Target please",
-              :filename_validator => "^[0-9]+-.+$",
-              :rake_options       => { :skip_directory => true },
-            }
-          )
+          expect_custom_prompts(host, 
+                                :filename_text      => "Target please",
+                                :filename_validator => "^[0-9]+-.+$",
+                                :rake_options       => { :skip_directory => true }).twice
 
           # if it doesn't ask again, it won't get the right task_params
           say ["", "bad-2", target]
@@ -1832,10 +1809,13 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         expect { subject.ask_file_location }.to raise_error signal_error
       end
 
-      context "with localized file upload" do
-        it "displays custom ftp option with blank prompts" do
+      context "with custom menu config" do
+        before do
           expect(I18n).to receive(:t).with("database_admin.menu_order").and_return(%w(local ftp://example.com/inbox/filename.txt))
           expect(I18n).to receive(:t).with("database_admin.local").and_return("The Local file")
+        end
+
+        it "displays custom ftp option with blank prompts" do
           expect(I18n).to receive(:t).with("database_admin.prompts", :default=>{}).and_return({})
           expect(subject).to receive(:ask_local_file_options).once
           say ""
@@ -1852,9 +1832,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         end
 
         it "displays custom ftp option with enabled array" do
-          expect(I18n).to receive(:t).with("database_admin.menu_order").and_return(%w(local ftp://example.com/inbox/filename.txt))
-          expect(I18n).to receive(:t).with("database_admin.local").and_return("The Local file")
-          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).and_return(:"example.com" => { :enabled_for => %w(dump backup) })
+          expect_custom_prompts("example.com", :enabled_for => %w(dump backup))
           expect(subject).to receive(:ask_local_file_options).once
           say ""
           subject.ask_file_location
@@ -1870,9 +1848,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
         end
 
         it "hides custom ftp option with other string prompts" do
-          expect(I18n).to receive(:t).with("database_admin.menu_order").and_return(%w(local ftp://example.com/inbox/filename.txt))
-          expect(I18n).to receive(:t).with("database_admin.local").and_return("The Local file")
-          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).and_return(:"example.com" => { :enabled_for => "backup" })
+          expect_custom_prompts("example.com", :enabled_for => "backup")
           expect(subject).to receive(:ask_local_file_options).once
           say ""
           subject.ask_file_location
@@ -2189,12 +2165,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
 
       context "with custom prompts" do
         before do
-          expect(I18n).to receive(:t).with("database_admin.prompts", :default => {}).twice.and_return(
-            host.to_sym => {
-              :filename_text      => "Target please",
-              :filename_validator => "^[0-9]+-.+$"
-            }
-          )
+          expect_custom_prompts(host, :filename_text => "Target please", :filename_validator => "^[0-9]+-.+$").twice
 
           # if it doesn't ask again, it won't get the right task_params
           say ["", "bad-2", target]
@@ -2475,5 +2446,10 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       subject.instance_variable_set(:@backup_type, "ftp")
       expect(subject).not_to be_local_backup
     end
+  end
+
+  def expect_custom_prompts(hostname, values)
+    expect(I18n).to receive(:t).with("database_admin.prompts", :default => {})
+                               .and_return(hostname.to_sym => values)
   end
 end


### PR DESCRIPTION
We were prompting for a local data filename and a remote url.
But since this is streaming, it does not make sense.

This now:

- properly populates the `:remote_file_name value`
- hides/shows the prompt selectively for dump, backup, restore
- has configurable rake options

related to:
- https://bugzilla.redhat.com/show_bug.cgi?id=1632433
- ManageIQ/manageiq-appliance_console#65

configuration has been tweaked:

```yaml
  database_admin:
    menu_order:
    - local
    - ftp://ftp.example.com/incoming/
    local: Local file
    prompts:
      ftp.example.com:
        enabled_for: ["backup", "dump"]
        filename_text: "The case number dash (-) filename. (e.g.: 12345-db.backup)"
        filename_validator: "^[0-9]{4,}-..*"
        rake_options:
          skip_directory: true
```