### PR TITLE
Fix `appliance_console_cli`

### DIFF
--- a/bin/appliance_console_cli
+++ b/bin/appliance_console_cli
@@ -4,4 +4,4 @@ require 'bundler'
 Bundler.setup
 
 require 'manageiq-appliance_console'
-ManageIQ::ApplianceConsole::Cli.parse(ARGV)
+ManageIQ::ApplianceConsole::Cli.parse(ARGV).run


### PR DESCRIPTION
Without calling `.run`, it will parse the options and do nothing (I think...)

For what it is worth, seems like this has been like this for a while (link below is from `darga`):

https://github.com/ManageIQ/manageiq-appliance/blob/68f588cd/LINK/bin/appliance_console_cli

So someone might want to check me on this to see if this is valid, but this is what the code looked like for the `ManageIQ::ApplianceConsole::Cli` (minus the current namespace) prior to the move.

https://github.com/ManageIQ/manageiq-gems-pending/pull/292


Rational
--------

The `.parse` command simply does a `Trollop.parse`, and then returns itself (`self`), while `.run` actually calls some commands based on the info it has parsed from the `cli` flags.

That said, the previous implementation (linked above), did the exact same thing, so either it has been broken for a long time (and unchecked) or the code under the hood allowed `.parse` to trigger code to fire further parts of the `appliance_console`.


Links
-----

* https://github.com/ManageIQ/manageiq-appliance/blob/68f588cd/LINK/bin/appliance_console_cli
* https://github.com/ManageIQ/manageiq-gems-pending/pull/292