### PR TITLE
Use Optimist

### DIFF
--- a/lib/manageiq/appliance_console/cli.rb
+++ b/lib/manageiq/appliance_console/cli.rb
@@ -1,4 +1,4 @@
-require 'trollop'
+require 'optimist'
 require 'pathname'
 
 # support for appliance_console methods
@@ -106,7 +106,7 @@ module ApplianceConsole
 
     def parse(args)
       args.shift if args.first == "--" # Handle when called through script/runner
-      self.options = Trollop.options(args) do
+      self.options = Optimist.options(args) do
         banner "Usage: appliance_console_cli [options]"
 
         opt :host,     "/etc/hosts name",    :type => :string,  :short => 'H'
@@ -147,7 +147,7 @@ module ApplianceConsole
         opt :extauth_opts,         "External Authentication Options",   :type => :string
         opt :server,               "{start|stop|restart} actions on evmserverd Server",   :type => :string
       end
-      Trollop.die :region, "needed when setting up a local database" if region_number_required? && options[:region].nil?
+      Optimist.die :region, "needed when setting up a local database" if region_number_required? && options[:region].nil?
       self
     end
 
@@ -156,7 +156,7 @@ module ApplianceConsole
     end
 
     def run
-      Trollop.educate unless set_host? || key? || database? || tmp_disk? || log_disk? ||
+      Optimist.educate unless set_host? || key? || database? || tmp_disk? || log_disk? ||
                              uninstall_ipa? || install_ipa? || certs? || extauth_opts? ||
                              time_zone? || date_time? || set_server_state? || set_replication?
       if set_host?

--- a/manageiq-appliance_console.gemspec
+++ b/manageiq-appliance_console.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "highline",                "~> 1.6.21"
   spec.add_runtime_dependency "i18n",                    "~> 0.7"
   spec.add_runtime_dependency "linux_admin",             ["~> 1.0", ">=1.2.2"]
+  spec.add_runtime_dependency "optimist",                "~> 3.0"
   spec.add_runtime_dependency "pg"
-  spec.add_runtime_dependency "trollop",                 "~> 2.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -3,13 +3,13 @@ describe ManageIQ::ApplianceConsole::Cli do
 
   describe "#parse" do
     it "fails if a region is not specified for a local database" do
-      expect { subject.parse(%w(--internal)) }.to raise_error(TrollopDieSpecError)
+      expect { subject.parse(%w(--internal)) }.to raise_error(OptimistDieSpecError)
     end
   end
 
   describe "#run" do
     it "should educate if parameters are not passed" do
-      expect { subject.parse([]).run }.to raise_error(TrollopEducateSpecError)
+      expect { subject.parse([]).run }.to raise_error(OptimistEducateSpecError)
     end
   end
 

--- a/spec/support/trollop.rb
+++ b/spec/support/trollop.rb
@@ -1,16 +1,16 @@
 require 'active_support/core_ext/string/strip'
-require 'trollop'
+require 'optimist'
 
-class TrollopEducateSpecError < StandardError; end
-class TrollopDieSpecError < StandardError; end
+class OptimistEducateSpecError < StandardError; end
+class OptimistDieSpecError < StandardError; end
 
 RSpec.configure do |config|
   config.before(:each) do
     err_string = <<-EOF.strip_heredoc
       Don't allow methods that exit the calling process to be executed in specs.
-      If you were testing that we call Trollop.educate or Trollop.die, expect that a TrollopEducateSpecError or TrollopDieSpecError be raised instead
+      If you were testing that we call Optimist.educate or Optimist.die, expect that a OptimistEducateSpecError or OptimistDieSpecError be raised instead
     EOF
-    allow(Trollop).to receive(:educate).and_raise(TrollopEducateSpecError.new(err_string))
-    allow(Trollop).to receive(:die).and_raise(TrollopDieSpecError.new(err_string))
+    allow(Optimist).to receive(:educate).and_raise(OptimistEducateSpecError.new(err_string))
+    allow(Optimist).to receive(:die).and_raise(OptimistDieSpecError.new(err_string))
   end
 end


### PR DESCRIPTION
`Trollop` is a deprecated gem, and has been renamed/replaced by [`Optimist`](https://github.com/ManageIQ/optimist).

This change might be dependent on `manageiq` making changes to this as well.  I don't think this should be merged until we have fully released `hammer`, since we might be a chance we need to release this gem for a bug fix yet.  Just getting this and others prepared currently, and will un-`[WIP]` when I think it is safe to merge this one.

Though, not making a release with this change might make it so nightly builds might have trouble once https://github.com/ManageIQ/manageiq/pull/18246 is merged, since that might not contain the dependency needed for the `cli` to run.  Will have to look into how this gem is installed on an appliance...

Update:  Installed via https://github.com/ManageIQ/manageiq-appliance/blob/1f8a6dcc/manageiq-appliance-dependencies.rb#L2 so this shouldn't break nightlies by merging the the above without this one, there will just be both `trollop` and `optimist` on an appliance for a while, along with the warning (since we don't have the version of `trollop` pegged in the gemspec.).

Links
-----
* Org search of current usage of old gem (hides some irrelevant repos):  [search](https://github.com/search?l=&q=Trollop+repo%3AManageIQ%2Fmanageiq+repo%3AManageIQ%2Fmanageiq-release+repo%3AManageIQ%2Fmanageiq-appliance_console+repo%3AManageIQ%2Fmanageiq-appliance-build+repo%3AManageIQ%2Fmanageiq-api+repo%3AManageIQ%2Fmanageiq-providers-vmware+repo%3AManageIQ%2Fhttpd_configmap_generator+repo%3AManageIQ%2Fguides&type=Code)