### PR TITLE
Fix hakiri warnings on `i18n`

### DIFF
--- a/manageiq-appliance_console.gemspec
+++ b/manageiq-appliance_console.gemspec
@@ -20,15 +20,15 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activerecord",            ">= 4.2.2"
-  spec.add_runtime_dependency "activesupport",           ">= 4.2.2"
+  spec.add_runtime_dependency "activerecord",            "~> 5.0.7.1"
+  spec.add_runtime_dependency "activesupport",           "~> 5.0.7.1"
   spec.add_runtime_dependency "awesome_spawn",           "~> 1.4"
   spec.add_runtime_dependency "bcrypt",                  "~> 3.1.10"
   spec.add_runtime_dependency "highline",                "~> 1.6.21"
-  spec.add_runtime_dependency "i18n",                    "~> 0.7"
   spec.add_runtime_dependency "linux_admin",             ["~> 1.0", ">=1.2.2"]
   spec.add_runtime_dependency "optimist",                "~> 3.0"
   spec.add_runtime_dependency "pg"
+  spec.add_runtime_dependency "rails-i18n",              "~> 5.x"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"


### PR DESCRIPTION
By using `manageiq` versions of rails dependencies.  This PR does two things:

- use `rails-i18n` instead of `i18n`, matching `manageiq` version
- matches the versions of `activesupport`/`activerecord` to `manageiq`

Version matching done at for the current versions at the time of writing:

https://github.com/ManageIQ/manageiq/blob/4cdafdbf/Gemfile#L59-L60

This ideally will avoid multiple versions of the gems on the system, as well as removing the `hakiri` warning for `i18n`.

**Note**:  We probably should wait to merge this until after the `hammer` release, just to ease bug fixes leading up to it.  Will toss a `[WIP]` on this for the time being as a reminder of that.