### PR TITLE
Fix logging when configure db

### DIFF
--- a/lib/manageiq/appliance_console/database_configuration.rb
+++ b/lib/manageiq/appliance_console/database_configuration.rb
@@ -217,8 +217,8 @@ FRIENDLY
     def validated
       !!validate!
     rescue => err
-      say_error(__method__, err.message)
       log_error(__method__, err.message)
+      say_error(__method__, err.message)
       false
     end
 


### PR DESCRIPTION
**Issue**: 
  last operator in `say_error`is throwing error and execution never reached `log_error`

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1625377

@miq-bot add-label  bug