### PR TITLE
Handle existing certs and support retun of cert generation

### DIFF
--- a/spec/certificate_authority_spec.rb
+++ b/spec/certificate_authority_spec.rb
@@ -40,7 +40,7 @@ describe ManageIQ::ApplianceConsole::CertificateAuthority do
 
     it "should configure http" do
       ipa_configured(true)
-      expect_run(/getcert/, anything, response) # getcert returns: the certificate already exist
+      expect_run(/getcert/, anything, response).at_least(3).times
 
       expect(LinuxAdmin::Service).to receive(:new).and_return(double("Service", :restart => true))
       expect(LinuxAdmin::Service).to receive(:new).and_return(double(:enable => double(:start => nil)))
@@ -66,7 +66,7 @@ describe ManageIQ::ApplianceConsole::CertificateAuthority do
 
     it "should configure postgres client" do
       ipa_configured(true)
-      expect_run(/getcert/, anything, response) # getcert returns: the certificate already exist
+      expect_run(/getcert/, anything, response).at_least(3).times
 
       allow(File).to receive(:exist?).and_return(true)
       expect(LinuxAdmin::Service).to receive(:new).and_return(double(:enable => double(:start => nil)))
@@ -91,7 +91,7 @@ describe ManageIQ::ApplianceConsole::CertificateAuthority do
 
     it "should install postgres server" do
       ipa_configured(true)
-      expect_run(/getcert/, anything, response) # getcert returns: the certificate already exist
+      expect_run(/getcert/, anything, response).at_least(3).times
 
       expect(ManageIQ::ApplianceConsole::InternalDatabaseConfiguration).to receive(:new)
         .and_return(double("config", :activate => true, :configure_postgres => true))


### PR DESCRIPTION
This PR will address:
   https://bugzilla.redhat.com/show_bug.cgi?id=1670138

This PR addresses a couple of related issues.

1 - If the self signed certs, that are auto-generated the first time the appliance is started,
    already exists "getcert request" would not overwrite them. This PR addresses this by first
    moving them.

2 - While working to resolve the above issue I realized that if "getcert request" was already
    successfully and certs are being track, then re-running the "getcert request" is actually
    a no-op, unless tracking is stopped with "getcert stop-tracking"
    This PR addresses this by running "getcert stop-tracking" when certs are already being tracked

    NOTE: If the certs are still valid on the cert authority the same certs will be provided.

**Testing**
One way to test this is to use the appliance_console to request a new ipa cert after the appliance
has been started at least once, which will create self signed certs if certs are not found.

The self signed certs will be created here:
```
/var/www/miq/vmdb/certs/server.cer
/var/www/miq/vmdb/certs/server.cer.key
```

```bash
# Start the appliance
systemctl start evmserverd

# Copy the self signed certs to x.SELF_SIGNED
cp /var/www/miq/vmdb/certs/server.cer /var/www/miq/vmdb/certs/server.cer.SELF_SIGNED
cp /var/www/miq/vmdb/certs/server.cer.key /var/www/miq/vmdb/certs/server.cer.key.SELF_SIGNED

# Run the appliance_console for appliance_console_cli to configure external auth with IPA, e.g:
appliance_console_cli --ipaserver=<my IPA server fully qualified hostname> --ipaprincipal=admin --ipapassword=<my IPA server's admin password>

# Run the appliance_console_cli to request signed certs
appliance_console_cli        --ca=ipa        --http-cert

# Ensure the certs created just created by the above command are different from the saved .SEFL_SIGNED ones.
diff -q /var/www/miq/vmdb/certs/server.cer /var/www/miq/vmdb/certs/server.cer.SELF_SIGNED
Files server.cer and server.cer.SELF_SIGNED differ

diff -q /var/www/miq/vmdb/certs/server.cer.key /var/www/miq/vmdb/certs/server.cer.key.SELF_SIGNED
Files server.cer.key and server.cer.key.SELF_SIGNED differ
```