### PR TITLE
Fix permissions on PG user home directory after disk mount

### DIFF
--- a/lib/manageiq/appliance_console/internal_database_configuration.rb
+++ b/lib/manageiq/appliance_console/internal_database_configuration.rb
@@ -82,6 +82,12 @@ module ApplianceConsole
                                     :filesystem_type     => PostgresAdmin.database_disk_filesystem,
                                     :logical_volume_path => PostgresAdmin.logical_volume_path).setup
       end
+
+      # if we mounted the disk onto the postgres user's home directory, fix the permissions
+      if mount_point.to_s == "/var/lib/pgsql"
+        FileUtils.chown(PostgresAdmin.user, PostgresAdmin.group, "/var/lib/pgsql")
+        FileUtils.chmod(0o700, "/var/lib/pgsql")
+      end
     end
 
     def initialize_postgresql

--- a/manageiq-appliance_console.gemspec
+++ b/manageiq-appliance_console.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "awesome_spawn",           "~> 1.4"
   spec.add_runtime_dependency "bcrypt",                  "~> 3.1.10"
   spec.add_runtime_dependency "highline",                "~> 1.6.21"
-  spec.add_runtime_dependency "i18n",                    "~> 0.7"
+  spec.add_runtime_dependency "i18n",                    "~> 0.8"
   spec.add_runtime_dependency "linux_admin",             ["~> 1.0", ">=1.2.2"]
   spec.add_runtime_dependency "optimist",                "~> 3.0"
   spec.add_runtime_dependency "pg"


### PR DESCRIPTION
When we moved from SCL to normal PG the data directory moved
into the postgres user's home directory (/var/lib/pgsql). We use
the directory over the data directory as a mount point for the
database filesystem.

Mounting the filesystem on the home directory causes permissions
issues during initdb as the postgres user expects to be able to
write into it's home directory. This PR fixes the permissions
when we mount on /var/lib/pgsql

cc @simaishi 