### PR TITLE
Remove pg cert handling

### DIFF
--- a/bin/appliance_console
+++ b/bin/appliance_console
@@ -346,27 +346,6 @@ Static Network Configuration
         end
         press_any_key
 
-      when I18n.t("advanced_settings.ca")
-        say("#{selection}\n\n")
-        begin
-          ca = CertificateAuthority.new(:hostname => host)
-          if ca.ask_questions && ca.activate
-            say "\ncertificate result: #{ca.status_string}"
-            unless ca.complete?
-              say "After the certificates are retrieved, rerun to update service configuration files"
-            end
-            press_any_key
-          else
-            say("\nCertificates not fetched.\n")
-            press_any_key
-          end
-        rescue AwesomeSpawn::CommandResultError => e
-          say e.result.output
-          say e.result.error
-          say ""
-          press_any_key
-        end
-
       when I18n.t("advanced_settings.evmstop")
         say("#{selection}\n\n")
         service = LinuxAdmin::Service.new("evmserverd")

--- a/lib/manageiq/appliance_console/cli.rb
+++ b/lib/manageiq/appliance_console/cli.rb
@@ -44,7 +44,7 @@ module ApplianceConsole
     end
 
     def certs?
-      options[:postgres_client_cert] || options[:postgres_server_cert] || options[:http_cert]
+      options[:http_cert]
     end
 
     def uninstall_ipa?
@@ -141,8 +141,6 @@ module ApplianceConsole
         opt :ca,                   "CA name used for certmonger",       :type => :string,  :default => "ipa"
         opt :timezone,             "Time zone",                         :type => :string
         opt :datetime,             "Date and time, in YYYY-MM-DDTHH:MM:SS (ISO8601) format", :type => :string
-        opt :postgres_client_cert, "install certs for postgres client", :type => :boolean
-        opt :postgres_server_cert, "install certs for postgres server", :type => :boolean
         opt :http_cert,            "install certs for http server",     :type => :boolean
         opt :extauth_opts,         "External Authentication Options",   :type => :string
         opt :server,               "{start|stop|restart} actions on evmserverd Server",   :type => :string
@@ -323,8 +321,6 @@ module ApplianceConsole
         :hostname => host,
         :realm    => options[:iparealm],
         :ca_name  => options[:ca],
-        :pgclient => options[:postgres_client_cert],
-        :pgserver => options[:postgres_server_cert],
         :http     => options[:http_cert],
         :verbose  => options[:verbose],
       )

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -258,13 +258,11 @@ describe ManageIQ::ApplianceConsole::Cli do
           :hostname => "client.domain.com",
           :realm    => nil,
           :ca_name  => "ipa",
-          :pgclient => true,
-          :pgserver => false,
           :http     => true,
           :verbose  => false,
         ).and_return(double(:activate => true, :status_string => "good", :complete? => true))
 
-      subject.parse(%w(--postgres-client-cert --http-cert)).run
+      subject.parse(["--http-cert"]).run
     end
 
     it "should basic install waiting (manual ca_name, verbose)" do
@@ -277,13 +275,11 @@ describe ManageIQ::ApplianceConsole::Cli do
           :hostname => "client.domain.com",
           :realm    => "realm.domain.com",
           :ca_name  => "super",
-          :pgclient => false,
-          :pgserver => true,
-          :http     => false,
+          :http     => true,
           :verbose  => true,
         ).and_return(double(:activate => true, :status_string => "good", :complete? => false))
 
-      subject.parse(%w(--postgres-server-cert --verbose --ca super --iparealm realm.domain.com)).run
+      subject.parse(%w(--http-cert --verbose --ca super --iparealm realm.domain.com)).run
     end
   end
 
@@ -568,20 +564,8 @@ describe ManageIQ::ApplianceConsole::Cli do
     end
 
     context "#certs?" do
-      it "should install certs if postgres client is specified" do
-        expect(subject.parse(%w(--postgres-client-cert))).to be_certs
-      end
-
-      it "should install certs if postgres server is specified" do
-        expect(subject.parse(%w(--postgres-server-cert))).to be_certs
-      end
-
       it "should install certs if a http is specified" do
         expect(subject.parse(%w(--http-cert))).to be_certs
-      end
-
-      it "should install certs if all params are specified" do
-        expect(subject.parse(%w(--postgres-client-cert --postgres-server-cert --http-cert))).to be_certs
       end
     end
   end

--- a/spec/support/trollop.rb
+++ b/spec/support/trollop.rb
@@ -12,5 +12,7 @@ RSpec.configure do |config|
     EOF
     allow(Optimist).to receive(:educate).and_raise(OptimistEducateSpecError.new(err_string))
     allow(Optimist).to receive(:die).and_raise(OptimistDieSpecError.new(err_string))
+    allow_any_instance_of(Optimist::Parser).to receive(:educate).and_raise(OptimistEducateSpecError.new(err_string))
+    allow_any_instance_of(Optimist::Parser).to receive(:die).and_raise(OptimistDieSpecError.new(err_string))
   end
 end


### PR DESCRIPTION
This removes a case from `appliance_console` that hasn't been accessible since 2014 and removes the cert configuration code from the CLI which hasn't worked since at least 2017 (https://github.com/ManageIQ/manageiq-appliance_console/pull/22).

~~Waiting on approval to remove this, otherwise I will investigate getting it up and running again if we think it's something people want.~~

Approval granted :smile: 