### PR TITLE
Do not attempt to restore db if evmserverd is running

### DIFF
--- a/lib/manageiq/appliance_console/database_admin.rb
+++ b/lib/manageiq/appliance_console/database_admin.rb
@@ -43,6 +43,11 @@ module ManageIQ
 
       def ask_questions
         setting_header
+        if action == :restore && LinuxAdmin::Service.new("evmserverd").running?
+          say("\nDatabase restore failed. Please execute the \“Stop EVM Server Processes\” command and try again.")
+          press_any_key
+          raise MiqSignalError
+        end
         say(DB_DUMP_WARNING) if action == :dump
         ask_file_location
         ask_for_tables_to_exclude_in_dump

--- a/spec/database_admin_spec.rb
+++ b/spec/database_admin_spec.rb
@@ -31,6 +31,15 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
 
         subject.ask_questions
       end
+
+      it "raises MiqSignalError for :restore action if evmserverd is running" do
+        service = double(:service)
+        expect(LinuxAdmin::Service).to receive(:new).and_return(service)
+        allow(service).to receive(:running?).and_return(true)
+        allow(subject).to receive(:press_any_key)
+
+        expect { subject.ask_questions }.to raise_error signal_error
+      end
     end
 
     describe "#activate" do
@@ -1821,7 +1830,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
           ]
         end
         before do
-          expect_custom_prompts(host, 
+          expect_custom_prompts(host,
                                 :filename_text      => "Target please",
                                 :filename_validator => "^[0-9]+-.+$",
                                 :rake_options       => { :skip_directory => true }).twice


### PR DESCRIPTION
Do not attempt to restore db if evmserverd is running

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1662991

