### PR TITLE
Fix logfile configuration bz 1720223

### DIFF
--- a/lib/manageiq/appliance_console/logical_volume_management.rb
+++ b/lib/manageiq/appliance_console/logical_volume_management.rb
@@ -34,8 +34,8 @@ module ApplianceConsole
       create_volume_group
       create_logical_volume_to_fill_volume_group
       format_logical_volume
-      mount_disk
       update_fstab
+      mount_disk
     end
 
     private
@@ -74,8 +74,7 @@ module ApplianceConsole
         FileUtils.rm_rf(mount_point)
         FileUtils.mkdir_p(mount_point)
       end
-      AwesomeSpawn.run!("mount", :params => {"-t" => filesystem_type,
-                                             nil  => [logical_volume.path, mount_point]})
+      AwesomeSpawn.run!("mount", :params => ["-a"])
     end
 
     def update_fstab

--- a/lib/manageiq/appliance_console/logical_volume_management.rb
+++ b/lib/manageiq/appliance_console/logical_volume_management.rb
@@ -80,19 +80,18 @@ module ApplianceConsole
 
     def update_fstab
       fstab = LinuxAdmin::FSTab.instance
-      return if fstab.entries.find { |e| e.mount_point == mount_point }
+      entry = fstab.entries.find { |e| e.mount_point == mount_point } || LinuxAdmin::FSTabEntry.new
+      fstab.entries.delete(entry)
 
-      entry = LinuxAdmin::FSTabEntry.new(
-        :device        => logical_volume.path,
-        :mount_point   => mount_point,
-        :fs_type       => filesystem_type,
-        :mount_options => "rw,noatime",
-        :dumpable      => 0,
-        :fsck_order    => 0
-      )
+      entry.device        = logical_volume_path
+      entry.mount_point   = mount_point
+      entry.fs_type       = filesystem_type
+      entry.mount_options = "rw,noatime"
+      entry.dumpable      = 0
+      entry.fsck_order    = 0
 
       fstab.entries << entry
-      fstab.write! # Test this more, whitespace is removed
+      fstab.write!
     end
   end
 end

--- a/lib/manageiq/appliance_console/logical_volume_management.rb
+++ b/lib/manageiq/appliance_console/logical_volume_management.rb
@@ -79,7 +79,7 @@ module ApplianceConsole
 
     def update_fstab
       fstab = LinuxAdmin::FSTab.instance
-      entry = fstab.entries.find { |e| e.mount_point == mount_point } || LinuxAdmin::FSTabEntry.new
+      entry = fstab.entries.find { |e| e.mount_point == mount_point.to_s } || LinuxAdmin::FSTabEntry.new
       fstab.entries.delete(entry)
 
       entry.device        = logical_volume_path

--- a/lib/manageiq/appliance_console/logical_volume_management.rb
+++ b/lib/manageiq/appliance_console/logical_volume_management.rb
@@ -35,6 +35,7 @@ module ApplianceConsole
       create_logical_volume_to_fill_volume_group
       format_logical_volume
       update_fstab
+      lazy_unmount_mount_point
       mount_disk
     end
 
@@ -67,6 +68,10 @@ module ApplianceConsole
 
     def format_logical_volume
       AwesomeSpawn.run!("mkfs.#{filesystem_type} #{logical_volume.path}")
+    end
+
+    def lazy_unmount_mount_point
+      AwesomeSpawn.run!("umount", :params => ["-l", mount_point.to_s]) if File.file?("/proc/mounts") && File.read("/proc/mounts").include?(" #{mount_point} ")
     end
 
     def mount_disk

--- a/manageiq-appliance_console.gemspec
+++ b/manageiq-appliance_console.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "bcrypt",                  "~> 3.1.10"
   spec.add_runtime_dependency "highline",                "~> 1.6.21"
   spec.add_runtime_dependency "i18n",                    "~> 0.8"
-  spec.add_runtime_dependency "linux_admin",             ["~> 1.0", ">=1.2.3"]
+  spec.add_runtime_dependency "linux_admin",             ["~> 1.0", ">=1.2.4"]
   spec.add_runtime_dependency "manageiq-password",       "~> 0.3"
   spec.add_runtime_dependency "optimist",                "~> 3.0"
   spec.add_runtime_dependency "pg"


### PR DESCRIPTION
DEPENDS ON https://github.com/ManageIQ/linux_admin/pull/208 and a new version of the gem
- unmount before mounting the new device in case there was an old device.
- Update fstab any time we run through this code, the directory may already be listed with a different backing device.
- We failed to match fstab previously because the input was a Pathname and we were comparing to a string
- mount the disk based on the fstab entry