### PR TITLE
Do not use unrecommended mount option "nobarrier"

### DIFF
--- a/lib/manageiq/appliance_console/temp_storage_configuration.rb
+++ b/lib/manageiq/appliance_console/temp_storage_configuration.rb
@@ -3,7 +3,7 @@ module ApplianceConsole
   class TempStorageConfiguration
     TEMP_DISK_FILESYSTEM_TYPE = "xfs".freeze
     TEMP_DISK_MOUNT_POINT     = Pathname.new("/var/www/miq_tmp").freeze
-    TEMP_DISK_MOUNT_OPTS      = "rw,noatime,nobarrier".freeze
+    TEMP_DISK_MOUNT_OPTS      = "rw,noatime".freeze
 
     attr_reader :disk
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1716404

Starting with RHEL6  the mount option **_nobarrier_** was no longer recommended.
Starting with RHEL8 the mount option **_nobarrier_** was no longer supported. The mount
command fails on RHEL8 if the **_nobarrier_** option is provided.

This PR removes the unrecommended _**nobarrier**_ mount option. I have tested this change
on both RHEL7 and RHEL8.

This change is required because the appliance console used the _**nobarrier**_ mount option
when configuring temporary storage, causing it to fail on RHEL8.

To Test:

1. Add an extra hard disk to the VM running the appliance.
2. Attempt to use the appliance_console_cli with the --tmpdisk flag to mount a temp storage disk.

e.g.:
`appliance_console_cli -t /dev/sdb`

