### PR TITLE
Exit with non-zero when database activation fails

### DIFF
--- a/lib/manageiq/appliance_console/cli.rb
+++ b/lib/manageiq/appliance_console/cli.rb
@@ -10,6 +10,8 @@ end
 
 module ManageIQ
 module ApplianceConsole
+  class CliError < StandardError; end
+
   class Cli
     attr_accessor :options
 
@@ -176,6 +178,10 @@ module ApplianceConsole
       install_certs if certs?
       extauth_opts if extauth_opts?
       set_server_state if set_server_state?
+    rescue CliError => e
+      say e
+      say ""
+      exit(1)
     rescue AwesomeSpawn::CommandResultError => e
       say e.result.output
       say e.result.error
@@ -214,17 +220,13 @@ module ApplianceConsole
       # initdb, relabel log directory for selinux, update configs,
       # start pg, create user, create db update the rails configuration,
       # verify, set up the database with region. activate does it all!
-      unless config.activate
-        say "Failed to configure internal database"
-        exit(1)
-      end
+      raise CliError, "Failed to configure internal database" unless config.activate
 
       # enable/start related services
       config.post_activation
     rescue RuntimeError => e
       say e.message
-      say "Failed to configure internal database"
-      exit(1)
+      raise CliError, "Failed to configure internal database"
     end
 
     def set_external_db
@@ -240,10 +242,7 @@ module ApplianceConsole
       }.delete_if { |_n, v| v.nil? })
 
       # call create_or_join_region (depends on region value)
-      unless config.activate
-        say "Failed to configure external database"
-        exit(1)
-      end
+      raise CliError, "Failed to configure external database" unless config.activate
 
       # enable/start related services
       config.post_activation

--- a/lib/manageiq/appliance_console/cli.rb
+++ b/lib/manageiq/appliance_console/cli.rb
@@ -225,8 +225,7 @@ module ApplianceConsole
       # enable/start related services
       config.post_activation
     rescue RuntimeError => e
-      say e.message
-      raise CliError, "Failed to configure internal database"
+      raise CliError, "Failed to configure internal database #{e.message}"
     end
 
     def set_external_db

--- a/lib/manageiq/appliance_console/cli.rb
+++ b/lib/manageiq/appliance_console/cli.rb
@@ -179,7 +179,7 @@ module ApplianceConsole
       extauth_opts if extauth_opts?
       set_server_state if set_server_state?
     rescue CliError => e
-      say(e)
+      say(e.message)
       say("")
       exit(1)
     rescue AwesomeSpawn::CommandResultError => e

--- a/lib/manageiq/appliance_console/cli.rb
+++ b/lib/manageiq/appliance_console/cli.rb
@@ -216,7 +216,7 @@ module ApplianceConsole
       # verify, set up the database with region. activate does it all!
       unless config.activate
         say "Failed to configure internal database"
-        return
+        exit(1)
       end
 
       # enable/start related services
@@ -224,6 +224,7 @@ module ApplianceConsole
     rescue RuntimeError => e
       say e.message
       say "Failed to configure internal database"
+      exit(1)
     end
 
     def set_external_db
@@ -241,7 +242,7 @@ module ApplianceConsole
       # call create_or_join_region (depends on region value)
       unless config.activate
         say "Failed to configure external database"
-        return
+        exit(1)
       end
 
       # enable/start related services

--- a/lib/manageiq/appliance_console/cli.rb
+++ b/lib/manageiq/appliance_console/cli.rb
@@ -179,8 +179,8 @@ module ApplianceConsole
       extauth_opts if extauth_opts?
       set_server_state if set_server_state?
     rescue CliError => e
-      say e
-      say ""
+      say(e)
+      say("")
       exit(1)
     rescue AwesomeSpawn::CommandResultError => e
       say e.result.output

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -136,14 +136,13 @@ describe ManageIQ::ApplianceConsole::Cli do
     expect { subject.run }.to raise_error(RuntimeError, "A password is required to configure a database")
   end
 
-  
   context "database activation failed" do
     before do
       expect(subject).to receive(:exit).with(1)
     end
 
     it "should not run post activation if internal database activation fails" do
-      subject.parse(%w(--internal --username user --password pass -r 1 --dbdisk x))
+      subject.parse(%w[--internal --username user --password pass -r 1 --dbdisk x])
       expect_v2_key
       expect(subject).to receive(:disk_from_string).and_return('x')
       expect(subject).to receive(:say).twice
@@ -163,7 +162,7 @@ describe ManageIQ::ApplianceConsole::Cli do
     end
 
     it "should not run activation if internal database not setting in a separate mount point" do
-      subject.parse(%w(--internal --username user --password pass -r 1))
+      subject.parse(%w[--internal --username user --password pass -r 1])
       expect_v2_key
       expect(subject).to receive(:disk_from_string).and_return(nil)
       expect(subject).to receive(:say).exactly(3).times
@@ -183,7 +182,7 @@ describe ManageIQ::ApplianceConsole::Cli do
     end
 
     it "should not run post activation if external database activation fails" do
-      subject.parse(%w(--hostname host --dbname db --username user --password pass -r 1))
+      subject.parse(%w[--hostname host --dbname db --username user --password pass -r 1])
       expect_v2_key
       expect(subject).to receive(:say).twice
       config_double = double(:activate => false)

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -145,7 +145,7 @@ describe ManageIQ::ApplianceConsole::Cli do
       subject.parse(%w[--internal --username user --password pass -r 1 --dbdisk x])
       expect_v2_key
       expect(subject).to receive(:disk_from_string).and_return('x')
-      expect(subject).to receive(:say).twice
+      expect(subject).to receive(:say).exactly(3).times
       config_double = double(:check_disk_is_mount_point => true, :activate => false)
       expect(ManageIQ::ApplianceConsole::InternalDatabaseConfiguration).to receive(:new)
         .with(:region            => 1,
@@ -156,7 +156,7 @@ describe ManageIQ::ApplianceConsole::Cli do
               :disk              => 'x',
               :run_as_evm_server => true)
         .and_return(config_double)
-      expect(config_double).to receive(:post_activation).with(no_args)
+      expect(config_double).to_not receive(:post_activation)
 
       subject.run
     end
@@ -165,7 +165,7 @@ describe ManageIQ::ApplianceConsole::Cli do
       subject.parse(%w[--internal --username user --password pass -r 1])
       expect_v2_key
       expect(subject).to receive(:disk_from_string).and_return(nil)
-      expect(subject).to receive(:say).exactly(3).times
+      expect(subject).to receive(:say).exactly(4).times
       config_double = double
       expect(ManageIQ::ApplianceConsole::InternalDatabaseConfiguration).to receive(:new)
         .with(:region            => 1,
@@ -184,7 +184,7 @@ describe ManageIQ::ApplianceConsole::Cli do
     it "should not run post activation if external database activation fails" do
       subject.parse(%w[--hostname host --dbname db --username user --password pass -r 1])
       expect_v2_key
-      expect(subject).to receive(:say).twice
+      expect(subject).to receive(:say).exactly(3).times
       config_double = double(:activate => false)
       expect(ManageIQ::ApplianceConsole::ExternalDatabaseConfiguration).to receive(:new)
         .with(:host        => 'host',
@@ -195,7 +195,7 @@ describe ManageIQ::ApplianceConsole::Cli do
               :password    => 'pass',
               :interactive => false)
         .and_return(config_double)
-      expect(config_double).to receive(:post_activation).with(no_args)
+      expect(config_double).to_not receive(:post_activation)
 
       subject.run
     end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -165,7 +165,7 @@ describe ManageIQ::ApplianceConsole::Cli do
       subject.parse(%w[--internal --username user --password pass -r 1])
       expect_v2_key
       expect(subject).to receive(:disk_from_string).and_return(nil)
-      expect(subject).to receive(:say).exactly(4).times
+      expect(subject).to receive(:say).exactly(3).times
       config_double = double
       expect(ManageIQ::ApplianceConsole::InternalDatabaseConfiguration).to receive(:new)
         .with(:region            => 1,


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1747202

Have the cli `exit(1)` in place of `return` when database activation fails. This will  ensure the shell status does not reflects the success code "0"

### To test

Attempt to configure the database using `appliance_console_cli` when it  has already been configured. Then check the shell status for the failed `appliance_console_cli` command with `echo $?` and confirm the shell status is not set to the success code "0"

```bash
/opt/rh/cfme-gemset/bin/appliance_console_cli -i -b /dev/sdb -S -d ${db_name} -U ${db_root} -p '${db_pass}'
echo $?
```

The spec test modifications expect `exit` when database activations fails. This causes `exit` not to actually run in the rspec environment, where it would in actual usage. This results in commands after the `exit` running in rspec environment, which require them to be handled by the test.

