### PR TITLE
Removing duplicate functions

### DIFF
--- a/lib/manageiq/appliance_console/cli.rb
+++ b/lib/manageiq/appliance_console/cli.rb
@@ -77,14 +77,6 @@ module ApplianceConsole
       options[:saml_unconfig]
     end
 
-    def saml_config?
-      options[:saml_config]
-    end
-
-    def saml_unconfig?
-      options[:saml_unconfig]
-    end
-
     def set_server_state?
       options[:server]
     end


### PR DESCRIPTION
Somehow the saml_config? and saml_unconfig? were duplicated with commit df723549. While not harmful, removing the dups.