### PR TITLE
update hostname regex to allow starting with digit

### DIFF
--- a/lib/manageiq/appliance_console/prompts.rb
+++ b/lib/manageiq/appliance_console/prompts.rb
@@ -13,7 +13,7 @@ module ApplianceConsole
     DOMAIN_REGEXP = /^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*(\.[a-z]{2,13})?$/
     INT_REGEXP    = /^[0-9]+$/
     NONE_REGEXP   = /^('?NONE'?)?$/i.freeze
-    HOSTNAME_REGEXP = /^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$/
+    HOSTNAME_REGEXP = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/.freeze
 
     def ask_for_uri(prompt, expected_scheme, opts = {})
       require 'uri'

--- a/spec/prompts_spec.rb
+++ b/spec/prompts_spec.rb
@@ -153,9 +153,21 @@ describe ManageIQ::ApplianceConsole::Prompts, :with_ui do
         expect(subject.ask_for_ip('prompt', '1.1.1.1')).to eq('dead:beef::1')
       end
 
-      it "should handle hostname" do
-        say %w(5x redhat.com)
+      it "should handle hostname beginning with a digit" do
+        say "198.51.100.1.example.com"
+        expect(subject.ask_for_ip_or_hostname("prompt", "1.1.1.1")).to eq("198.51.100.1.example.com")
+        expect_heard("Enter the prompt: |1.1.1.1| ")
+      end
+
+      it "should handle hostname beginning with a letter" do
+        say "redhat.com"
         expect(subject.ask_for_ip_or_hostname("prompt", "1.1.1.1")).to eq("redhat.com")
+        expect_heard("Enter the prompt: |1.1.1.1| ")
+      end
+
+      it "should fail on hostname length check if > 63 octets" do
+        say ["re" * 35 + ".com", "198.51.100.1.example.com"]
+        expect(subject.ask_for_ip_or_hostname("prompt", "1.1.1.1")).to eq("198.51.100.1.example.com")
         expect_heard ["Enter the prompt: |1.1.1.1| ", "Please provide a valid Hostname or IP Address.", prompt]
       end
     end
@@ -173,9 +185,21 @@ describe ManageIQ::ApplianceConsole::Prompts, :with_ui do
         expect_heard("Enter the prompt: |1.1.1.1| ")
       end
 
-      it "should handle hostname" do
-        say %w(5x redhat.com)
+      it "should handle hostname starting with a digit" do
+        say "198.51.100.1.example.com"
+        expect(subject.ask_for_ip_or_hostname_or_none("prompt", "1.1.1.1")).to eq("198.51.100.1.example.com")
+        expect_heard("Enter the prompt: |1.1.1.1| ")
+      end
+
+      it "should handle hostname starting with a letter" do
+        say "redhat.com"
         expect(subject.ask_for_ip_or_hostname_or_none("prompt", "1.1.1.1")).to eq("redhat.com")
+        expect_heard("Enter the prompt: |1.1.1.1| ")
+      end
+
+      it "should fail on hostname length check if > 63 octets" do
+        say ["re" * 35 + ".com", "198.51.100.1.example.com"]
+        expect(subject.ask_for_ip_or_hostname_or_none("prompt", "1.1.1.1")).to eq("198.51.100.1.example.com")
         expect_heard ["Enter the prompt: |1.1.1.1| ", "Please provide a valid Hostname or IP Address.", prompt]
       end
 


### PR DESCRIPTION
Hostnames can start with a digit per https://tools.ietf.org/html/rfc1123, and has a restriction on length that we're not handling, and should be updated. 

@yrudman please review? i and regexes are not friends

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1785257