### PR TITLE
Use the regex to validate hostnames when we set them

### DIFF
--- a/bin/appliance_console
+++ b/bin/appliance_console
@@ -280,7 +280,7 @@ Static Network Configuration
 
         when 'hostname'
           say("Hostname Configuration\n\n")
-          new_host = just_ask("new hostname", host)
+          new_host = just_ask("new hostname", host, HOSTNAME_REGEXP, "Please enter a valid hostname")
 
           if new_host != host
             say("Applying new hostname...")


### PR DESCRIPTION
We only validate hostnames today when you test them (options 1 and 4 in the console), not when you're actually applying them (options 1 and 5), so currently you can verify that ```_test1``` shouldn't be valid due to the underscore but you will be able to set it anyway. 

[Highline's](https://github.com/JEG2/highline/blob/bf489b632afd92c68df0b2c1f348afb66b5495aa/lib/highline/question.rb#L144) [third arg for this method](https://github.com/ManageIQ/manageiq-appliance_console/blob/7372c5b864fc76494708362e4a68dc1f00234680/lib/manageiq/appliance_console/prompts.rb#L192) is [the validation](https://github.com/ManageIQ/manageiq-appliance_console/pull/106/files#diff-11f3fdac8dc445b3e93dd2459f62b9a9L16) so we should use it. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1786282

@kbrock sorry, another super trivial one, but any chance I could get you to review please? 

Behavior is all tested already, see [the specs on 106](https://github.com/ManageIQ/manageiq-appliance_console/pull/106)

## edit:
![Screen Shot 2019-12-28 at 2 32 13 PM](https://user-images.githubusercontent.com/16326669/71548596-dedf0f80-297e-11ea-97cc-cb685f3d5fc5.png)
#### welp okay cool then 
I mean that's about how I feel too so 