### PR TITLE
Deduplicate the SCAP_RULES_DIR constant

### DIFF
--- a/bin/appliance_console
+++ b/bin/appliance_console
@@ -19,8 +19,6 @@ include HighLine::SystemExtensions
 
 require 'manageiq/appliance_console/i18n'
 
-SCAP_RULES_DIR = File.expand_path("productization/appliance_console/config", ManageIQ::ApplianceConsole::RAILS_ROOT)
-
 $terminal.wrap_at = 80
 $terminal.page_at = 35
 
@@ -538,7 +536,7 @@ Static Network Configuration
 
       when I18n.t("advanced_settings.scap")
         say("#{selection}\n\n")
-        ManageIQ::ApplianceConsole::Scap.new(SCAP_RULES_DIR).lockdown
+        ManageIQ::ApplianceConsole::Scap.new.lockdown
         press_any_key
 
       when I18n.t("advanced_settings.summary")

--- a/lib/manageiq/appliance_console/cli.rb
+++ b/lib/manageiq/appliance_console/cli.rb
@@ -8,9 +8,6 @@ unless defined?(say)
   end
 end
 
-# define SCAP_RULES_DIR for scap fucntionality
-SCAP_RULES_DIR = File.expand_path("productization/appliance_console/config", ManageIQ::ApplianceConsole::RAILS_ROOT)
-
 module ManageIQ
 module ApplianceConsole
   class CliError < StandardError; end
@@ -355,7 +352,7 @@ module ApplianceConsole
 
     def openscap
       say("Configuring Openscap")
-      ManageIQ::ApplianceConsole::Scap.new(SCAP_RULES_DIR).lockdown
+      ManageIQ::ApplianceConsole::Scap.new.lockdown
     end
 
     def config_tmp_disk

--- a/lib/manageiq/appliance_console/scap.rb
+++ b/lib/manageiq/appliance_console/scap.rb
@@ -3,7 +3,9 @@ require 'linux_admin'
 module ManageIQ
 module ApplianceConsole
   class Scap
-    def initialize(rules_dir)
+    RULES_DIR = File.expand_path("productization/appliance_console/config", ManageIQ::ApplianceConsole::RAILS_ROOT).freeze
+
+    def initialize(rules_dir = RULES_DIR)
       @rules_dir = rules_dir
     end
 


### PR DESCRIPTION
642781d50 added a second definition of the constant when adding
the scap feature to the cli. This caused a warning on console startup:

manageiq-appliance_console-5.3.0/bin/appliance_console:22: warning: already initialized constant SCAP_RULES_DIR
manageiq-appliance_console-5.3.0/lib/manageiq/appliance_console/cli.rb:12: warning: previous definition of SCAP_RULES_DIR was here

Instead of re-defining the constant we can move it into the Scap
class and make it the default parameter value for #initialize