### PR TITLE
Add rubygems.manageiq.org for handsoap dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+source 'http://rubygems.manageiq.org'
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in manageiq-smartstate.gemspec


### PR DESCRIPTION
Fixes failure in https://travis-ci.org/ManageIQ/manageiq-appliance_console/jobs/636962979