### PR TITLE
Add support for the oidc introspection endpoint

### DIFF
--- a/lib/manageiq/appliance_console/cli.rb
+++ b/lib/manageiq/appliance_console/cli.rb
@@ -169,6 +169,7 @@ module ApplianceConsole
         opt :oidc_client_host,     "Optional Appliance host used for OpenID-Connect Authentication", :type => :string
         opt :oidc_client_id,       "The OpenID-Connect Provider Client ID",                          :type => :string
         opt :oidc_client_secret,   "The OpenID-Connect Provider Client Secret",                      :type => :string
+        opt :oidc_introspection_endpoint, "The OpenID-Connect Provider Introspect Endpoint",         :type => :string
         opt :oidc_enable_sso,      "Optionally enable SSO with OpenID-Connect Authentication",       :type => :boolean, :default => false
         opt :oidc_unconfig,        "Unconfigure Appliance OpenID-Connect Authentication",            :type => :boolean, :default => false
         opt :server,               "{start|stop|restart} actions on evmserverd Server",   :type => :string

--- a/lib/manageiq/appliance_console/oidc_authentication.rb
+++ b/lib/manageiq/appliance_console/oidc_authentication.rb
@@ -52,10 +52,12 @@ module ManageIQ
         debug_msg("Copying Apache OpenID-Connect Config files ...")
         copy_template(HTTPD_CONFIG_DIRECTORY, "manageiq-remote-user-openidc.conf")
         copy_template(HTTPD_CONFIG_DIRECTORY, "manageiq-external-auth-openidc.conf.erb",
-                      :miq_appliance              => host,
-                      :oidc_provider_metadata_url => options[:oidc_url],
-                      :oidc_client_id             => options[:oidc_client_id],
-                      :oidc_client_secret         => options[:oidc_client_secret])
+                      :miq_appliance               => host,
+                      :oidc_provider_metadata_url  => options[:oidc_url],
+                      :oidc_client_id              => options[:oidc_client_id],
+                      :oidc_client_secret          => options[:oidc_client_secret],
+                      :oidc_introspection_endpoint => options[:oidc_introspection_endpoint],
+)
       end
 
       def remove_apache_oidc_configfiles
@@ -74,6 +76,7 @@ module ManageIQ
         raise "Must specify the OpenID-Connect Provider URL via --oidc-url" if options[:oidc_url].blank?
         raise "Must specify the OpenID-Connect Client ID via --oidc-client-id" if options[:oidc_client_id].blank?
         raise "Must specify the OpenID-Connect Client Secret via --oidc-client-secret" if options[:oidc_client_secret].blank?
+        raise "Must specify the OpenID-Connect Client Introspection Endpoint --oidc-introspection-endpoint" if options[:oidc_introspection_endpoint].blank?
       end
 
       # Appliance Settings

--- a/lib/manageiq/appliance_console/oidc_authentication.rb
+++ b/lib/manageiq/appliance_console/oidc_authentication.rb
@@ -5,9 +5,9 @@ module ManageIQ
 
       attr_accessor :host, :options
 
-      URL_SUFFIX = /\/\.well-known\/openid-configuration$/
-      INTROSPECT_SUFFIX = "/protocol/openid-connect/token/introspect"
-      INTROSPECT_ENDPOINT_ERROR = "Unable to derive the OpenID-Connect Client Introspection Endpoint. Use --oidc-introspection-endpoint"
+      URL_SUFFIX = /\/\.well-known\/openid-configuration$/.freeze
+      INTROSPECT_SUFFIX = "/protocol/openid-connect/token/introspect".freeze
+      INTROSPECT_ENDPOINT_ERROR = "Unable to derive the OpenID-Connect Client Introspection Endpoint. Use --oidc-introspection-endpoint".freeze
 
       def initialize(options)
         @options = options
@@ -61,8 +61,7 @@ module ManageIQ
                       :oidc_provider_metadata_url  => options[:oidc_url],
                       :oidc_client_id              => options[:oidc_client_id],
                       :oidc_client_secret          => options[:oidc_client_secret],
-                      :oidc_introspection_endpoint => options[:oidc_introspection_endpoint],
-)
+                      :oidc_introspection_endpoint => options[:oidc_introspection_endpoint])
       end
 
       def remove_apache_oidc_configfiles
@@ -85,6 +84,7 @@ module ManageIQ
 
       def derive_introspection_endpoint
         return if options[:oidc_introspection_endpoint].present?
+
         options[:oidc_introspection_endpoint] = options[:oidc_url].sub(URL_SUFFIX, INTROSPECT_SUFFIX) if options[:oidc_url].match(URL_SUFFIX)
         raise INTROSPECT_ENDPOINT_ERROR if options[:oidc_introspection_endpoint].blank?
       end

--- a/spec/oidc_authentication_spec.rb
+++ b/spec/oidc_authentication_spec.rb
@@ -1,6 +1,7 @@
 describe ManageIQ::ApplianceConsole::OIDCAuthentication do
   let(:client_host) { "client.example.com" }
   let(:oidc_url) { "http://oidc.example.com:8080/auth/realms/manageiq/.well-known/openid-configuration" }
+  let(:oidc_introspection) { "http://oidc.example.com:8080/auth/realms/manageiq/protocol/openid-connect/token/introspect" }
 
   context "configuring OpenID-Connect" do
     it "fails without the oidc-url option specified" do
@@ -39,16 +40,20 @@ describe ManageIQ::ApplianceConsole::OIDCAuthentication do
 
       oidc_client_id     = client_host
       oidc_client_secret = "17106c0d-8446-4b87-82e4-b7408ad583d0"
-      subject = described_class.new(:oidc_url => oidc_url, :oidc_client_id => oidc_client_id, :oidc_client_secret => oidc_client_secret)
+      subject = described_class.new(:oidc_url                    => oidc_url,
+                                    :oidc_client_id              => oidc_client_id,
+                                    :oidc_client_secret          => oidc_client_secret,
+                                    :oidc_introspection_endpoint => oidc_introspection)
 
       allow(subject).to receive(:copy_template)
       expect(subject).to receive(:copy_template).with(described_class::HTTPD_CONFIG_DIRECTORY, "manageiq-remote-user-openidc.conf").and_return(true)
       expect(subject).to receive(:copy_template).with(described_class::HTTPD_CONFIG_DIRECTORY,
                                                       "manageiq-external-auth-openidc.conf.erb",
-                                                      :miq_appliance              => client_host,
-                                                      :oidc_client_id             => oidc_client_id,
-                                                      :oidc_client_secret         => oidc_client_secret,
-                                                      :oidc_provider_metadata_url => oidc_url).and_return(true)
+                                                      :miq_appliance               => client_host,
+                                                      :oidc_client_id              => oidc_client_id,
+                                                      :oidc_client_secret          => oidc_client_secret,
+                                                      :oidc_introspection_endpoint => oidc_introspection,
+                                                      :oidc_provider_metadata_url  => oidc_url).and_return(true)
 
       expect(subject).to receive(:say).with("Setting Appliance Authentication Settings to OpenID-Connect ...")
       expect(subject).to receive(:say).with("Configuring OpenID-Connect Authentication for https://#{client_host} ...")
@@ -73,10 +78,11 @@ describe ManageIQ::ApplianceConsole::OIDCAuthentication do
       alternate_client_host = "alternate.example.com"
       oidc_client_id        = alternate_client_host
       oidc_client_secret    = "18106c0d-8456-4b87-83e5-c74a9ad583e0"
-      subject = described_class.new(:oidc_url           => oidc_url,
-                                    :oidc_client_id     => oidc_client_id,
-                                    :oidc_client_secret => oidc_client_secret,
-                                    :oidc_enable_sso    => true)
+      subject = described_class.new(:oidc_url                    => oidc_url,
+                                    :oidc_client_id              => oidc_client_id,
+                                    :oidc_client_secret          => oidc_client_secret,
+                                    :oidc_introspection_endpoint => oidc_introspection,
+                                    :oidc_enable_sso             => true)
 
       allow(subject).to receive(:copy_template)
       expect(subject).to receive(:copy_template).with(described_class::HTTPD_CONFIG_DIRECTORY, "manageiq-remote-user-openidc.conf").and_return(true)
@@ -85,6 +91,7 @@ describe ManageIQ::ApplianceConsole::OIDCAuthentication do
                                                       :miq_appliance              => alternate_client_host,
                                                       :oidc_client_id             => oidc_client_id,
                                                       :oidc_client_secret         => oidc_client_secret,
+                                                      :oidc_introspection_endpoint => oidc_introspection,
                                                       :oidc_provider_metadata_url => oidc_url).and_return(true)
 
       expect(subject).to receive(:say).with("Setting Appliance Authentication Settings to OpenID-Connect ...")

--- a/spec/oidc_authentication_spec.rb
+++ b/spec/oidc_authentication_spec.rb
@@ -25,7 +25,55 @@ describe ManageIQ::ApplianceConsole::OIDCAuthentication do
       expect(subject.configure(client_host)).to eq(false)
     end
 
-    it "succeeds with provider url, client id and secret specified and restarts httpd" do
+    it "fails when unable to derive introspect endpoint" do
+      oidc_client_id     = client_host
+      oidc_client_secret = "17106c0d-8446-4b87-82e4-b7408ad583d0"
+      subject = described_class.new(:oidc_url                    => "http://oidc.provider.example.com/.not-so-well-known",
+                                    :oidc_client_id              => oidc_client_id,
+                                    :oidc_client_secret          => oidc_client_secret)
+
+
+      expect(subject).to receive(:say).with(/Unable to derive the OpenID-Connect Client Introspection Endpoint/)
+      expect(subject.configure(client_host)).to eq(false)
+    end
+
+    it "succeeds with provider url, client id and secret specified, derives introspect and restarts httpd" do
+      httpd_service = double(@spec_name, :running? => true)
+      expect(httpd_service).to receive(:restart)
+      expect(LinuxAdmin::Service).to receive(:new).with("httpd").and_return(httpd_service)
+
+      expect(ManageIQ::ApplianceConsole::Utilities).to receive(:rake_run).with("evm:settings:set",
+                                                                               ["/authentication/mode=httpd",
+                                                                                "/authentication/httpd_role=true",
+                                                                                "/authentication/saml_enabled=false",
+                                                                                "/authentication/oidc_enabled=true",
+                                                                                "/authentication/sso_enabled=false",
+                                                                                "/authentication/provider_type=oidc"])
+
+      oidc_client_id     = client_host
+      oidc_client_secret = "17106c0d-8446-4b87-82e4-b7408ad583d0"
+      subject = described_class.new(:oidc_url                    => oidc_url,
+                                    :oidc_client_id              => oidc_client_id,
+                                    :oidc_client_secret          => oidc_client_secret)
+
+      allow(subject).to receive(:copy_template)
+      expect(subject).to receive(:copy_template).with(described_class::HTTPD_CONFIG_DIRECTORY, "manageiq-remote-user-openidc.conf").and_return(true)
+      expect(subject).to receive(:copy_template).with(described_class::HTTPD_CONFIG_DIRECTORY,
+                                                      "manageiq-external-auth-openidc.conf.erb",
+                                                      :miq_appliance               => client_host,
+                                                      :oidc_client_id              => oidc_client_id,
+                                                      :oidc_client_secret          => oidc_client_secret,
+                                                      :oidc_introspection_endpoint => oidc_introspection,
+                                                      :oidc_provider_metadata_url  => oidc_url).and_return(true)
+
+      expect(subject).to receive(:say).with("Setting Appliance Authentication Settings to OpenID-Connect ...")
+      expect(subject).to receive(:say).with("Configuring OpenID-Connect Authentication for https://#{client_host} ...")
+
+      expect(subject).to receive(:say).with("Restarting httpd ...")
+      expect(subject.configure(client_host)).to eq(true)
+    end
+
+    it "succeeds with provider url, client id secret and introspect specified and restarts httpd" do
       httpd_service = double(@spec_name, :running? => true)
       expect(httpd_service).to receive(:restart)
       expect(LinuxAdmin::Service).to receive(:new).with("httpd").and_return(httpd_service)
@@ -81,7 +129,6 @@ describe ManageIQ::ApplianceConsole::OIDCAuthentication do
       subject = described_class.new(:oidc_url                    => oidc_url,
                                     :oidc_client_id              => oidc_client_id,
                                     :oidc_client_secret          => oidc_client_secret,
-                                    :oidc_introspection_endpoint => oidc_introspection,
                                     :oidc_enable_sso             => true)
 
       allow(subject).to receive(:copy_template)

--- a/spec/oidc_authentication_spec.rb
+++ b/spec/oidc_authentication_spec.rb
@@ -28,10 +28,9 @@ describe ManageIQ::ApplianceConsole::OIDCAuthentication do
     it "fails when unable to derive introspect endpoint" do
       oidc_client_id     = client_host
       oidc_client_secret = "17106c0d-8446-4b87-82e4-b7408ad583d0"
-      subject = described_class.new(:oidc_url                    => "http://oidc.provider.example.com/.not-so-well-known",
-                                    :oidc_client_id              => oidc_client_id,
-                                    :oidc_client_secret          => oidc_client_secret)
-
+      subject = described_class.new(:oidc_url           => "http://oidc.provider.example.com/.not-so-well-known",
+                                    :oidc_client_id     => oidc_client_id,
+                                    :oidc_client_secret => oidc_client_secret)
 
       expect(subject).to receive(:say).with(/Unable to derive the OpenID-Connect Client Introspection Endpoint/)
       expect(subject.configure(client_host)).to eq(false)
@@ -52,9 +51,9 @@ describe ManageIQ::ApplianceConsole::OIDCAuthentication do
 
       oidc_client_id     = client_host
       oidc_client_secret = "17106c0d-8446-4b87-82e4-b7408ad583d0"
-      subject = described_class.new(:oidc_url                    => oidc_url,
-                                    :oidc_client_id              => oidc_client_id,
-                                    :oidc_client_secret          => oidc_client_secret)
+      subject = described_class.new(:oidc_url           => oidc_url,
+                                    :oidc_client_id     => oidc_client_id,
+                                    :oidc_client_secret => oidc_client_secret)
 
       allow(subject).to receive(:copy_template)
       expect(subject).to receive(:copy_template).with(described_class::HTTPD_CONFIG_DIRECTORY, "manageiq-remote-user-openidc.conf").and_return(true)
@@ -126,20 +125,20 @@ describe ManageIQ::ApplianceConsole::OIDCAuthentication do
       alternate_client_host = "alternate.example.com"
       oidc_client_id        = alternate_client_host
       oidc_client_secret    = "18106c0d-8456-4b87-83e5-c74a9ad583e0"
-      subject = described_class.new(:oidc_url                    => oidc_url,
-                                    :oidc_client_id              => oidc_client_id,
-                                    :oidc_client_secret          => oidc_client_secret,
-                                    :oidc_enable_sso             => true)
+      subject = described_class.new(:oidc_url           => oidc_url,
+                                    :oidc_client_id     => oidc_client_id,
+                                    :oidc_client_secret => oidc_client_secret,
+                                    :oidc_enable_sso    => true)
 
       allow(subject).to receive(:copy_template)
       expect(subject).to receive(:copy_template).with(described_class::HTTPD_CONFIG_DIRECTORY, "manageiq-remote-user-openidc.conf").and_return(true)
       expect(subject).to receive(:copy_template).with(described_class::HTTPD_CONFIG_DIRECTORY,
                                                       "manageiq-external-auth-openidc.conf.erb",
-                                                      :miq_appliance              => alternate_client_host,
-                                                      :oidc_client_id             => oidc_client_id,
-                                                      :oidc_client_secret         => oidc_client_secret,
+                                                      :miq_appliance               => alternate_client_host,
+                                                      :oidc_client_id              => oidc_client_id,
+                                                      :oidc_client_secret          => oidc_client_secret,
                                                       :oidc_introspection_endpoint => oidc_introspection,
-                                                      :oidc_provider_metadata_url => oidc_url).and_return(true)
+                                                      :oidc_provider_metadata_url  => oidc_url).and_return(true)
 
       expect(subject).to receive(:say).with("Setting Appliance Authentication Settings to OpenID-Connect ...")
       expect(subject).to receive(:say).with("Configuring OpenID-Connect Authentication for https://#{alternate_client_host} ...")


### PR DESCRIPTION
Fixes ManageIQ/manageiq#19866

This PR adds support for the oidc introspection endpoint to the appliance console CLI. Combined with other PRs in other github repos support for the ManageIQ API  will be moved out of code and into the Apache configuration.

**Dependent PRs**
https://github.com/ManageIQ/manageiq-appliance/pull/282
https://github.com/ManageIQ/manageiq-api/pull/828
https://github.com/ManageIQ/manageiq/pull/20131

To Test:

Run the command of the form

```bash
appliance_console_cli \
  --oidc-config \
  --oidc-url="http://my-keycloak.example.com:8080/auth/realms/miq/.well-known/openid-configuration" \
  --oidc-client-host="my-miq.example.com" \
  --oidc-client-id="my-oidc-client"  \
  --oidc-client-secret="********" \
  --oidc-introspection-endpoint="https://my-keycloak.example.com:8443/auth/realms/miq/protocol/openid-connect/token/introspect"
```
