### PR TITLE
Try to fetch introspect endpoint from the provider metadata

### DIFF
--- a/lib/manageiq/appliance_console/cli.rb
+++ b/lib/manageiq/appliance_console/cli.rb
@@ -169,7 +169,7 @@ module ApplianceConsole
         opt :oidc_client_host,     "Optional Appliance host used for OpenID-Connect Authentication", :type => :string
         opt :oidc_client_id,       "The OpenID-Connect Provider Client ID",                          :type => :string
         opt :oidc_client_secret,   "The OpenID-Connect Provider Client Secret",                      :type => :string
-        opt :oidc_insecure,        "Fetch the OpenID-Connect Introspect Endpoint in insecure mode (development)", :type => :boolean, :default => false
+        opt :oidc_insecure,        "OpenID-Connect Insecure No SSL Verify (development)",            :type => :boolean, :default => false
         opt :oidc_introspection_endpoint, "The OpenID-Connect Provider Introspect Endpoint",         :type => :string
         opt :oidc_enable_sso,      "Optionally enable SSO with OpenID-Connect Authentication",       :type => :boolean, :default => false
         opt :oidc_unconfig,        "Unconfigure Appliance OpenID-Connect Authentication",            :type => :boolean, :default => false

--- a/lib/manageiq/appliance_console/cli.rb
+++ b/lib/manageiq/appliance_console/cli.rb
@@ -169,6 +169,7 @@ module ApplianceConsole
         opt :oidc_client_host,     "Optional Appliance host used for OpenID-Connect Authentication", :type => :string
         opt :oidc_client_id,       "The OpenID-Connect Provider Client ID",                          :type => :string
         opt :oidc_client_secret,   "The OpenID-Connect Provider Client Secret",                      :type => :string
+        opt :oidc_insecure,        "Fetch the OpenID-Connect Introspect Endpoint in insecure mode (development)", :type => :boolean, :default => false
         opt :oidc_introspection_endpoint, "The OpenID-Connect Provider Introspect Endpoint",         :type => :string
         opt :oidc_enable_sso,      "Optionally enable SSO with OpenID-Connect Authentication",       :type => :boolean, :default => false
         opt :oidc_unconfig,        "Unconfigure Appliance OpenID-Connect Authentication",            :type => :boolean, :default => false

--- a/lib/manageiq/appliance_console/oidc_authentication.rb
+++ b/lib/manageiq/appliance_console/oidc_authentication.rb
@@ -66,10 +66,12 @@ module ManageIQ
                       :oidc_client_secret          => options[:oidc_client_secret],
                       :oidc_introspection_endpoint => options[:oidc_introspection_endpoint])
 
-        File.open("#{HTTPD_CONFIG_DIRECTORY}/manageiq-external-auth-openidc.conf", "a") do |f|
-          f.write("\nOIDCSSLValidateServer      Off\n")
-          f.write("OIDCOAuthSSLValidateServer Off\n")
-        end if options[:oidc_insecure]
+        if options[:oidc_insecure]
+          File.open("#{HTTPD_CONFIG_DIRECTORY}/manageiq-external-auth-openidc.conf", "a") do |f|
+            f.write("\nOIDCSSLValidateServer      Off\n")
+            f.write("OIDCOAuthSSLValidateServer Off\n")
+          end
+        end
       end
 
       def remove_apache_oidc_configfiles

--- a/lib/manageiq/appliance_console/oidc_authentication.rb
+++ b/lib/manageiq/appliance_console/oidc_authentication.rb
@@ -65,6 +65,11 @@ module ManageIQ
                       :oidc_client_id              => options[:oidc_client_id],
                       :oidc_client_secret          => options[:oidc_client_secret],
                       :oidc_introspection_endpoint => options[:oidc_introspection_endpoint])
+
+        File.open("#{HTTPD_CONFIG_DIRECTORY}/manageiq-external-auth-openidc.conf", "a") do |f|
+          f.write("\nOIDCSSLValidateServer      Off\n")
+          f.write("OIDCOAuthSSLValidateServer Off\n")
+        end if options[:oidc_insecure]
       end
 
       def remove_apache_oidc_configfiles

--- a/lib/manageiq/appliance_console/oidc_authentication.rb
+++ b/lib/manageiq/appliance_console/oidc_authentication.rb
@@ -1,3 +1,6 @@
+require "net/http"
+require "uri"
+
 module ManageIQ
   module ApplianceConsole
     class OIDCAuthentication
@@ -85,8 +88,24 @@ module ManageIQ
       def derive_introspection_endpoint
         return if options[:oidc_introspection_endpoint].present?
 
-        options[:oidc_introspection_endpoint] = options[:oidc_url].sub(URL_SUFFIX, INTROSPECT_SUFFIX) if options[:oidc_url].match(URL_SUFFIX)
+        options[:oidc_introspection_endpoint] = fetch_introspection_endpoint || compose_introspection_endpoint
         raise INTROSPECT_ENDPOINT_ERROR if options[:oidc_introspection_endpoint].blank?
+      end
+
+      def fetch_introspection_endpoint
+        uri = URI.parse(options[:oidc_url])
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = (uri.scheme == "https")
+
+        request = Net::HTTP::Get.new(uri.request_uri)
+        request.basic_auth(options[:oidc_client_id], options[:oidc_client_secret])
+        response = http.request(request)
+
+        JSON.parse(response.body)["introspection_endpoint"]
+      end
+
+      def compose_introspection_endpoint
+        options[:oidc_url].sub(URL_SUFFIX, INTROSPECT_SUFFIX) if options[:oidc_url].match(URL_SUFFIX)
       end
 
       # Appliance Settings

--- a/lib/manageiq/appliance_console/oidc_authentication.rb
+++ b/lib/manageiq/appliance_console/oidc_authentication.rb
@@ -96,7 +96,7 @@ module ManageIQ
         uri = URI.parse(options[:oidc_url])
         http = Net::HTTP.new(uri.host, uri.port)
         http.use_ssl = (uri.scheme == "https")
-        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        http.verify_mode = OpenSSL::SSL::VERIFY_NONE if options[:oidc_insecure]
 
         request = Net::HTTP::Get.new(uri.request_uri)
         request.basic_auth(options[:oidc_client_id], options[:oidc_client_secret])
@@ -105,7 +105,7 @@ module ManageIQ
         JSON.parse(response.body)["introspection_endpoint"]
       rescue => err
         say("Failed to fetch introspection endpoint - #{err}")
-        return nil
+        nil
       end
 
       # Appliance Settings

--- a/spec/oidc_authentication_spec.rb
+++ b/spec/oidc_authentication_spec.rb
@@ -26,6 +26,7 @@ describe ManageIQ::ApplianceConsole::OIDCAuthentication do
     end
 
     it "fails when unable to derive introspect endpoint" do
+      allow_any_instance_of(Net::HTTP).to receive(:request).and_return(double(:body => {}.to_json))
       oidc_client_id     = client_host
       oidc_client_secret = "17106c0d-8446-4b87-82e4-b7408ad583d0"
       subject = described_class.new(:oidc_url           => "http://oidc.provider.example.com/.not-so-well-known",
@@ -36,7 +37,47 @@ describe ManageIQ::ApplianceConsole::OIDCAuthentication do
       expect(subject.configure(client_host)).to eq(false)
     end
 
+    it "succeeds with provider url, client id and secret specified, fetches introspect from metadata and restarts httpd" do
+      allow_any_instance_of(Net::HTTP).to receive(:request).and_return(double(:body => {"introspection_endpoint" => oidc_introspection}.to_json))
+      httpd_service = double(@spec_name, :running? => true)
+      expect(httpd_service).to receive(:restart)
+      expect(LinuxAdmin::Service).to receive(:new).with("httpd").and_return(httpd_service)
+
+      expect(ManageIQ::ApplianceConsole::Utilities).to receive(:rake_run).with("evm:settings:set",
+                                                                               ["/authentication/mode=httpd",
+                                                                                "/authentication/httpd_role=true",
+                                                                                "/authentication/saml_enabled=false",
+                                                                                "/authentication/oidc_enabled=true",
+                                                                                "/authentication/sso_enabled=false",
+                                                                                "/authentication/provider_type=oidc"])
+
+      oidc_client_id     = client_host
+      oidc_client_secret = "17106c0d-8446-4b87-82e4-b7408ad583d0"
+      subject = described_class.new(:oidc_url           => oidc_url,
+                                    :oidc_client_id     => oidc_client_id,
+                                    :oidc_client_secret => oidc_client_secret)
+
+      expect(subject).to_not receive(:compose_introspection_endpoint)
+
+      allow(subject).to receive(:copy_template)
+      expect(subject).to receive(:copy_template).with(described_class::HTTPD_CONFIG_DIRECTORY, "manageiq-remote-user-openidc.conf").and_return(true)
+      expect(subject).to receive(:copy_template).with(described_class::HTTPD_CONFIG_DIRECTORY,
+                                                      "manageiq-external-auth-openidc.conf.erb",
+                                                      :miq_appliance               => client_host,
+                                                      :oidc_client_id              => oidc_client_id,
+                                                      :oidc_client_secret          => oidc_client_secret,
+                                                      :oidc_introspection_endpoint => oidc_introspection,
+                                                      :oidc_provider_metadata_url  => oidc_url).and_return(true)
+
+      expect(subject).to receive(:say).with("Setting Appliance Authentication Settings to OpenID-Connect ...")
+      expect(subject).to receive(:say).with("Configuring OpenID-Connect Authentication for https://#{client_host} ...")
+
+      expect(subject).to receive(:say).with("Restarting httpd ...")
+      expect(subject.configure(client_host)).to eq(true)
+    end
+
     it "succeeds with provider url, client id and secret specified, derives introspect and restarts httpd" do
+      allow_any_instance_of(Net::HTTP).to receive(:request).and_return(double(:body => {}.to_json))
       httpd_service = double(@spec_name, :running? => true)
       expect(httpd_service).to receive(:restart)
       expect(LinuxAdmin::Service).to receive(:new).with("httpd").and_return(httpd_service)
@@ -110,6 +151,7 @@ describe ManageIQ::ApplianceConsole::OIDCAuthentication do
     end
 
     it "succeeds with client host, enabling SSO, and restarts httpd" do
+      allow_any_instance_of(Net::HTTP).to receive(:request).and_return(double(:body => {}.to_json))
       httpd_service = double(@spec_name, :running? => true)
       expect(httpd_service).to receive(:restart)
       expect(LinuxAdmin::Service).to receive(:new).with("httpd").and_return(httpd_service)


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-appliance_console/issues/119

This PR adds support to attempt to fetch the introspection endpoint by querying the provider metadata URL.

The logic for deriving the introspection URL used to be:

```
if introspection url is not specified:

try to derive the introspection value from the the metadata url value
If not possible, fail by requiring the :oidc_introspection_endpoint option.
```
The new logic for deriving the introspection URL will become:

```
if introspection url is not specified:

try to fetch the introspection endpoint from the provider metadata
if not successful fail by requiring the :oidc_introspection_endpoint option.
```
