### PR TITLE
Remove rbnacl-libsodium, will add rbnacl-devel RPM

### DIFF
--- a/manageiq-appliance_console.gemspec
+++ b/manageiq-appliance_console.gemspec
@@ -33,7 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "optimist",                "~> 3.0"
   spec.add_runtime_dependency "pg"
   spec.add_runtime_dependency "rbnacl",                  ">= 3.2", "< 5.0"
-  spec.add_runtime_dependency "rbnacl-libsodium"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"


### PR DESCRIPTION
see: https://github.com/RubyCrypto/rbnacl-libsodium#discontinued

@Fryguy, @agrare, @gtanzillo and @simaishi Need to add the rbnacl-devel RPM in PR:
https://github.com/ManageIQ/manageiq-rpm_build/pull/117