### PR TITLE
Toggle Settings.prototype.messaging_type for Kafka support

### DIFF
--- a/bin/appliance_console
+++ b/bin/appliance_console
@@ -441,7 +441,6 @@ Static Network Configuration
 
           message_client = MessageClientConfiguration.new
           if message_client.ask_questions && message_client.activate
-            message_client.post_activation
             say("\nMessage Client configured successfully.\n")
             press_any_key
           else

--- a/bin/appliance_console
+++ b/bin/appliance_console
@@ -441,6 +441,7 @@ Static Network Configuration
 
           message_client = MessageClientConfiguration.new
           if message_client.ask_questions && message_client.activate
+            message_client.post_activation
             say("\nMessage Client configured successfully.\n")
             press_any_key
           else

--- a/lib/manageiq/appliance_console/message_configuration.rb
+++ b/lib/manageiq/appliance_console/message_configuration.rb
@@ -151,6 +151,12 @@ module ManageIQ
         result = ManageIQ::ApplianceConsole::Utilities.rake_run("evm:settings:set", ["/prototype/messaging_type=#{value}"])
         raise parse_errors(result).join(', ') if result.failure?
       end
+
+      def restart_evmserverd
+        say("Restart evmserverd if it is running...")
+        evmserverd_service = LinuxAdmin::Service.new("evmserverd")
+        evmserverd_service.restart if evmserverd_service.running?
+      end
     end
   end
 end

--- a/lib/manageiq/appliance_console/message_configuration.rb
+++ b/lib/manageiq/appliance_console/message_configuration.rb
@@ -133,9 +133,6 @@ module ManageIQ
         true
       end
 
-      #
-      # Network validation
-      #
       def host_reachable?(host, what)
         require 'net/ping'
         say("Checking connectivity to #{host} ... ")
@@ -146,6 +143,13 @@ module ManageIQ
         end
         say("Succeeded.")
         true
+      end
+
+      def configure_messaging_type(value)
+        say(__method__.to_s.tr("_", " ").titleize)
+
+        result = ManageIQ::ApplianceConsole::Utilities.rake_run("evm:settings:set", ["/prototype/messaging_type=#{value}"])
+        raise parse_errors(result).join(', ') if result.failure?
       end
     end
   end

--- a/lib/manageiq/appliance_console/message_configuration_client.rb
+++ b/lib/manageiq/appliance_console/message_configuration_client.rb
@@ -25,6 +25,7 @@ module ManageIQ
           create_client_properties          # Create the client.properties configuration fle
           fetch_truststore_from_server      # Fetch the Java Keystore from the Kafka Server
           configure_messaging_type("kafka") # Settings.prototype.messaging_type = 'kafka'
+          restart_evmserverd
         rescue AwesomeSpawn::CommandResultError => e
           say(e.result.output)
           say(e.result.error)
@@ -36,12 +37,6 @@ module ManageIQ
           return false
         end
         true
-      end
-
-      def post_activation
-        say("Restart evmserverd if it is running...")
-        evmserverd_service = LinuxAdmin::Service.new("evmserverd")
-        evmserverd_service.restart if evmserverd_service.running?
       end
 
       def ask_for_parameters
@@ -81,8 +76,9 @@ module ManageIQ
       end
 
       def deactivate
-        remove_installed_files
         configure_messaging_type("miq_queue") # Settings.prototype.messaging_type = 'miq_queue'
+        restart_evmserverd
+        remove_installed_files
       end
     end
   end

--- a/lib/manageiq/appliance_console/message_configuration_client.rb
+++ b/lib/manageiq/appliance_console/message_configuration_client.rb
@@ -21,9 +21,10 @@ module ManageIQ
 
       def activate
         begin
-          configure_messaging_yaml     # Set up the local message client in case EVM is actually running on this, Message Server
-          create_client_properties     # Create the client.properties configuration fle
-          fetch_truststore_from_server # Fetch the Java Keystore from the Kafka Server
+          configure_messaging_yaml          # Set up the local message client in case EVM is actually running on this, Message Server
+          create_client_properties          # Create the client.properties configuration fle
+          fetch_truststore_from_server      # Fetch the Java Keystore from the Kafka Server
+          configure_messaging_type("kafka") # Settings.prototype.messaging_type = 'kafka'
         rescue AwesomeSpawn::CommandResultError => e
           say(e.result.output)
           say(e.result.error)
@@ -75,6 +76,7 @@ module ManageIQ
 
       def deactivate
         remove_installed_files
+        configure_messaging_type("miq_queue") # Settings.prototype.messaging_type = 'miq_queue'
       end
     end
   end

--- a/lib/manageiq/appliance_console/message_configuration_client.rb
+++ b/lib/manageiq/appliance_console/message_configuration_client.rb
@@ -38,6 +38,12 @@ module ManageIQ
         true
       end
 
+      def post_activation
+        say("Restart evmserverd if it is running...")
+        evmserverd_service = LinuxAdmin::Service.new("evmserverd")
+        evmserverd_service.restart if evmserverd_service.running?
+      end
+
       def ask_for_parameters
         say("\nMessage Client Parameters:\n\n")
 

--- a/lib/manageiq/appliance_console/message_configuration_server.rb
+++ b/lib/manageiq/appliance_console/message_configuration_server.rb
@@ -60,9 +60,7 @@ module ManageIQ
         say("Starting kafka and configure it to start on reboots ...")
         LinuxAdmin::Service.new("kafka").start.enable
 
-        say("Restart evmserverd if it is running...")
-        evmserverd_service = LinuxAdmin::Service.new("evmserverd")
-        evmserverd_service.restart if evmserverd_service.running?
+        restart_evmserverd
       end
 
       def ask_for_parameters
@@ -173,10 +171,11 @@ module ManageIQ
       end
 
       def deactivate
+        configure_messaging_type("miq_queue") # Settings.prototype.messaging_type = 'miq_queue'
+        restart_evmserverd
         remove_installed_files
         unconfigure_firewall
         deactivate_services
-        configure_messaging_type("miq_queue") # Settings.prototype.messaging_type = 'miq_queue'
       end
 
       def unconfigure_firewall

--- a/lib/manageiq/appliance_console/message_configuration_server.rb
+++ b/lib/manageiq/appliance_console/message_configuration_server.rb
@@ -59,6 +59,10 @@ module ManageIQ
 
         say("Starting kafka and configure it to start on reboots ...")
         LinuxAdmin::Service.new("kafka").start.enable
+
+        say("Restart evmserverd if it is running...")
+        evmserverd_service = LinuxAdmin::Service.new("evmserverd")
+        evmserverd_service.restart if evmserverd_service.running?
       end
 
       def ask_for_parameters

--- a/lib/manageiq/appliance_console/message_configuration_server.rb
+++ b/lib/manageiq/appliance_console/message_configuration_server.rb
@@ -32,13 +32,14 @@ module ManageIQ
 
       def activate
         begin
-          create_jaas_config           # Create the message server jaas config file
-          create_client_properties     # Create the client.properties config
-          create_logs_directory        # Create the logs directory:
-          configure_firewall           # Open the firewall for message port 9093
-          configure_keystore           # Populate the Java Keystore
-          create_server_properties     # Update the /opt/message/config/server.properties
-          configure_messaging_yaml     # Set up the local message client in case EVM is actually running on this, Message Server
+          create_jaas_config                # Create the message server jaas config file
+          create_client_properties          # Create the client.properties config
+          create_logs_directory             # Create the logs directory:
+          configure_firewall                # Open the firewall for message port 9093
+          configure_keystore                # Populate the Java Keystore
+          create_server_properties          # Update the /opt/message/config/server.properties
+          configure_messaging_yaml          # Set up the local message client in case EVM is actually running on this, Message Server
+          configure_messaging_type("kafka") # Settings.prototype.messaging_type = 'kafka'
         rescue AwesomeSpawn::CommandResultError => e
           say(e.result.output)
           say(e.result.error)
@@ -171,6 +172,7 @@ module ManageIQ
         remove_installed_files
         unconfigure_firewall
         deactivate_services
+        configure_messaging_type("miq_queue") # Settings.prototype.messaging_type = 'miq_queue'
       end
 
       def unconfigure_firewall

--- a/lib/manageiq/appliance_console/message_configuration_server.rb
+++ b/lib/manageiq/appliance_console/message_configuration_server.rb
@@ -8,7 +8,7 @@ module ManageIQ
     class MessageServerConfiguration < MessageConfiguration
       attr_reader :server_hostname, :jaas_config_path,
                   :server_properties_path, :server_properties_sample_path,
-                  :ca_cert_path, :ca_cert_srl_path, :ca_key_path, :cert_file_path, :cert_signed_path,
+                  :ca_cert_srl_path, :ca_key_path, :cert_file_path, :cert_signed_path,
                   :keystore_files, :installed_files
 
       def initialize(options = {})
@@ -20,7 +20,6 @@ module ManageIQ
         @server_properties_path            = config_dir_path.join("server.properties")
         @server_properties_sample_path     = sample_config_dir_path.join("server.properties")
 
-        @ca_cert_path                      = keystore_dir_path.join("ca-cert")
         @ca_cert_srl_path                  = keystore_dir_path.join("ca-cert.srl")
         @ca_key_path                       = keystore_dir_path.join("ca-key")
         @cert_file_path                    = keystore_dir_path.join("cert-file")

--- a/spec/message_configuration_client_spec.rb
+++ b/spec/message_configuration_client_spec.rb
@@ -200,13 +200,17 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
   describe "#restart_evmserverd" do
     it "restarts evmserverd if it is running" do
       expect(subject).to receive(:say)
-      expect(LinuxAdmin::Service).to receive(:new).with("evmserverd").and_return(double(@spec_name, :running? => true, :restart => nil))
+      evmserverd = double(@spec_name, :running? => true)
+      expect(evmserverd).to receive(:restart)
+      expect(LinuxAdmin::Service).to receive(:new).with("evmserverd").and_return(evmserverd)
       expect(subject.send(:restart_evmserverd)).to be_nil
     end
 
     it "does not restart evmserverd if it is not running" do
       expect(subject).to receive(:say)
-      expect(LinuxAdmin::Service).to receive(:new).with("evmserverd").and_return(double(@spec_name, :running? => false))
+      evmserverd = double(@spec_name, :running? => false)
+      expect(evmserverd).to_not receive(:restart)
+      expect(LinuxAdmin::Service).to receive(:new).with("evmserverd").and_return(evmserverd)
       expect(subject.send(:restart_evmserverd)).to be_nil
     end
   end

--- a/spec/message_configuration_client_spec.rb
+++ b/spec/message_configuration_client_spec.rb
@@ -193,4 +193,18 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
       expect(subject.send(:fetch_truststore_from_server)).to be_nil
     end
   end
+
+  describe "#post_activation" do
+    it "restarts evmserverd if it is running" do
+      expect(subject).to receive(:say)
+      expect(LinuxAdmin::Service).to receive(:new).with("evmserverd").and_return(double(@spec_name, :running? => true, :restart => nil))
+      expect(subject.send(:post_activation)).to be_nil
+    end
+
+    it "does not restart evmserverd if it is not running" do
+      expect(subject).to receive(:say)
+      expect(LinuxAdmin::Service).to receive(:new).with("evmserverd").and_return(double(@spec_name, :running? => false))
+      expect(subject.send(:post_activation)).to be_nil
+    end
+  end
 end

--- a/spec/message_configuration_client_spec.rb
+++ b/spec/message_configuration_client_spec.rb
@@ -200,7 +200,8 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
   describe "#restart_evmserverd" do
     it "restarts evmserverd if it is running" do
       expect(subject).to receive(:say)
-      evmserverd = double(@spec_name, :running? => true)
+      evmserverd = LinuxAdmin::Service.new("evmserverd")
+      expect(evmserverd).to receive(:running?).and_return(true)
       expect(evmserverd).to receive(:restart)
       expect(LinuxAdmin::Service).to receive(:new).with("evmserverd").and_return(evmserverd)
       expect(subject.send(:restart_evmserverd)).to be_nil
@@ -208,7 +209,8 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
 
     it "does not restart evmserverd if it is not running" do
       expect(subject).to receive(:say)
-      evmserverd = double(@spec_name, :running? => false)
+      evmserverd = LinuxAdmin::Service.new("evmserverd")
+      expect(evmserverd).to receive(:running?).and_return(false)
       expect(evmserverd).to_not receive(:restart)
       expect(LinuxAdmin::Service).to receive(:new).with("evmserverd").and_return(evmserverd)
       expect(subject.send(:restart_evmserverd)).to be_nil

--- a/spec/message_configuration_client_spec.rb
+++ b/spec/message_configuration_client_spec.rb
@@ -194,17 +194,17 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
     end
   end
 
-  describe "#post_activation" do
+  describe "#restart_evmserverd" do
     it "restarts evmserverd if it is running" do
       expect(subject).to receive(:say)
       expect(LinuxAdmin::Service).to receive(:new).with("evmserverd").and_return(double(@spec_name, :running? => true, :restart => nil))
-      expect(subject.send(:post_activation)).to be_nil
+      expect(subject.send(:restart_evmserverd)).to be_nil
     end
 
     it "does not restart evmserverd if it is not running" do
       expect(subject).to receive(:say)
       expect(LinuxAdmin::Service).to receive(:new).with("evmserverd").and_return(double(@spec_name, :running? => false))
-      expect(subject.send(:post_activation)).to be_nil
+      expect(subject.send(:restart_evmserverd)).to be_nil
     end
   end
 end

--- a/spec/message_configuration_client_spec.rb
+++ b/spec/message_configuration_client_spec.rb
@@ -151,8 +151,11 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
         production:
           hostname: my-kafka-server.example.com
           port: 9093
-          username: admin
-          password: #{ManageIQ::Password.try_encrypt("super_secret")}
+          security.protocol: SASL_SSL
+          ssl.ca.location: "#{@tmp_base_dir}/config/keystore/ca-cert"
+          sasl.mechanism: PLAIN
+          sasl.username: admin
+          sasl.password: #{ManageIQ::Password.try_encrypt("super_secret")}
         test:
           hostname: localhost
           port: 9092

--- a/spec/message_configuration_server_spec.rb
+++ b/spec/message_configuration_server_spec.rb
@@ -291,14 +291,20 @@ describe ManageIQ::ApplianceConsole::MessageServerConfiguration do
     it "starts the needed services" do
       expect(subject).to receive(:say).exactly(3).times
 
-      evmserverd = double(@spec_name, :running? => true)
+      evmserverd = LinuxAdmin::Service.new("evmserverd")
+      expect(evmserverd).to receive(:running?).and_return(true)
       expect(evmserverd).to receive(:restart)
 
-      service = double(@spec_name, :start => double(:enable => nil))
-      expect(service).to receive(:start)
+      zookeeper = LinuxAdmin::Service.new("zookeeper")
+      expect(zookeeper).to receive(:start).and_return(zookeeper)
+      expect(zookeeper).to receive(:enable)
 
-      expect(LinuxAdmin::Service).to receive(:new).with("zookeeper").and_return(service)
-      expect(LinuxAdmin::Service).to receive(:new).with("kafka").and_return(service)
+      kafka = LinuxAdmin::Service.new("kafka")
+      expect(kafka).to receive(:start).and_return(kafka)
+      expect(kafka).to receive(:enable)
+
+      expect(LinuxAdmin::Service).to receive(:new).with("zookeeper").and_return(zookeeper)
+      expect(LinuxAdmin::Service).to receive(:new).with("kafka").and_return(kafka)
       expect(LinuxAdmin::Service).to receive(:new).with("evmserverd").and_return(evmserverd)
 
       expect(subject.send(:post_activation)).to be_nil
@@ -307,16 +313,21 @@ describe ManageIQ::ApplianceConsole::MessageServerConfiguration do
     it "does not restart evmserverd if it is not running" do
       expect(subject).to receive(:say).exactly(3).times
 
-      evmserverd = double(@spec_name, :running? => false)
-      expect(evmserverd).not_to receive(:restart)
+      evmserverd = LinuxAdmin::Service.new("evmserverd")
+      expect(evmserverd).to receive(:running?).and_return(false)
+      expect(evmserverd).to_not receive(:restart)
 
-      service = double(@spec_name, :start => double(:enable => nil))
-      expect(service).to receive(:start)
+      zookeeper = LinuxAdmin::Service.new("zookeeper")
+      expect(zookeeper).to receive(:start).and_return(zookeeper)
+      expect(zookeeper).to receive(:enable)
 
-      expect(LinuxAdmin::Service).to receive(:new).with("zookeeper").and_return(service)
-      expect(LinuxAdmin::Service).to receive(:new).with("kafka").and_return(service)
+      kafka = LinuxAdmin::Service.new("kafka")
+      expect(kafka).to receive(:start).and_return(kafka)
+      expect(kafka).to receive(:enable)
+
+      expect(LinuxAdmin::Service).to receive(:new).with("zookeeper").and_return(zookeeper)
+      expect(LinuxAdmin::Service).to receive(:new).with("kafka").and_return(kafka)
       expect(LinuxAdmin::Service).to receive(:new).with("evmserverd").and_return(evmserverd)
-
       expect(subject.send(:post_activation)).to be_nil
     end
   end

--- a/spec/message_configuration_server_spec.rb
+++ b/spec/message_configuration_server_spec.rb
@@ -283,4 +283,22 @@ describe ManageIQ::ApplianceConsole::MessageServerConfiguration do
       expect(subject.send(:configure_messaging_yaml)).to be_nil
     end
   end
+
+  describe "#post_activation" do
+    it "starts the needed services" do
+      expect(subject).to receive(:say).exactly(3).times
+      expect(LinuxAdmin::Service).to receive(:new).with("zookeeper").and_return(double(@spec_name, :start => double(:enable => nil)))
+      expect(LinuxAdmin::Service).to receive(:new).with("kafka").and_return(double(@spec_name, :start => double(:enable => nil)))
+      expect(LinuxAdmin::Service).to receive(:new).with("evmserverd").and_return(double(@spec_name, :running? => true, :restart => nil))
+      expect(subject.send(:post_activation)).to be_nil
+    end
+
+    it "does not restart evmserverd if it is not running" do
+      expect(subject).to receive(:say).exactly(3).times
+      expect(LinuxAdmin::Service).to receive(:new).with("zookeeper").and_return(double(@spec_name, :start => double(:enable => nil)))
+      expect(LinuxAdmin::Service).to receive(:new).with("kafka").and_return(double(@spec_name, :start => double(:enable => nil)))
+      expect(LinuxAdmin::Service).to receive(:new).with("evmserverd").and_return(double(@spec_name, :running? => false))
+      expect(subject.send(:post_activation)).to be_nil
+    end
+  end
 end

--- a/spec/message_configuration_server_spec.rb
+++ b/spec/message_configuration_server_spec.rb
@@ -308,7 +308,13 @@ describe ManageIQ::ApplianceConsole::MessageServerConfiguration do
       expect(subject).to receive(:say).exactly(3).times
 
       evmserverd = double(@spec_name, :running? => false)
-      expect(evmserverd).to_not receive(:restart)
+      expect(evmserverd).not_to receive(:restart)
+
+      service = double(@spec_name, :start => double(:enable => nil))
+      expect(service).to receive(:start)
+
+      expect(LinuxAdmin::Service).to receive(:new).with("zookeeper").and_return(service)
+      expect(LinuxAdmin::Service).to receive(:new).with("kafka").and_return(service)
       expect(LinuxAdmin::Service).to receive(:new).with("evmserverd").and_return(evmserverd)
 
       expect(subject.send(:post_activation)).to be_nil

--- a/spec/message_configuration_server_spec.rb
+++ b/spec/message_configuration_server_spec.rb
@@ -290,17 +290,27 @@ describe ManageIQ::ApplianceConsole::MessageServerConfiguration do
   describe "#post_activation" do
     it "starts the needed services" do
       expect(subject).to receive(:say).exactly(3).times
-      expect(LinuxAdmin::Service).to receive(:new).with("zookeeper").and_return(double(@spec_name, :start => double(:enable => nil)))
-      expect(LinuxAdmin::Service).to receive(:new).with("kafka").and_return(double(@spec_name, :start => double(:enable => nil)))
-      expect(LinuxAdmin::Service).to receive(:new).with("evmserverd").and_return(double(@spec_name, :running? => true, :restart => nil))
+
+      evmserverd = double(@spec_name, :running? => true)
+      expect(evmserverd).to receive(:restart)
+
+      service = double(@spec_name, :start => double(:enable => nil))
+      expect(service).to receive(:start)
+
+      expect(LinuxAdmin::Service).to receive(:new).with("zookeeper").and_return(service)
+      expect(LinuxAdmin::Service).to receive(:new).with("kafka").and_return(service)
+      expect(LinuxAdmin::Service).to receive(:new).with("evmserverd").and_return(evmserverd)
+
       expect(subject.send(:post_activation)).to be_nil
     end
 
     it "does not restart evmserverd if it is not running" do
       expect(subject).to receive(:say).exactly(3).times
-      expect(LinuxAdmin::Service).to receive(:new).with("zookeeper").and_return(double(@spec_name, :start => double(:enable => nil)))
-      expect(LinuxAdmin::Service).to receive(:new).with("kafka").and_return(double(@spec_name, :start => double(:enable => nil)))
-      expect(LinuxAdmin::Service).to receive(:new).with("evmserverd").and_return(double(@spec_name, :running? => false))
+
+      evmserverd = double(@spec_name, :running? => false)
+      expect(evmserverd).to_not receive(:restart)
+      expect(LinuxAdmin::Service).to receive(:new).with("evmserverd").and_return(evmserverd)
+
       expect(subject.send(:post_activation)).to be_nil
     end
   end

--- a/spec/message_configuration_server_spec.rb
+++ b/spec/message_configuration_server_spec.rb
@@ -263,8 +263,11 @@ describe ManageIQ::ApplianceConsole::MessageServerConfiguration do
         production:
           hostname: my-host-name.example.com
           port: 9093
-          username: admin
-          password: #{ManageIQ::Password.try_encrypt("super_secret")}
+          security.protocol: SASL_SSL
+          ssl.ca.location: "#{@tmp_base_dir}/config/keystore/ca-cert"
+          sasl.mechanism: PLAIN
+          sasl.username: admin
+          sasl.password: #{ManageIQ::Password.try_encrypt("super_secret")}
         test:
           hostname: localhost
           port: 9092


### PR DESCRIPTION
This PR will add support for setting the messaging_type Settings to _kafka_ when activating kafka and back to _miq_queue_ when deactivating kafka


Fixes https://github.com/ManageIQ/manageiq-appliance_console/issues/136