### PR TITLE
remove duplicate class attr writer

### DIFF
--- a/lib/manageiq-appliance_console.rb
+++ b/lib/manageiq-appliance_console.rb
@@ -11,10 +11,6 @@ module ManageIQ
     def self.logger
       @logger ||= ManageIQ::ApplianceConsole::Logger.instance
     end
-
-    def self.logger=(logger)
-      @logger = logger
-    end
   end
 end
 


### PR DESCRIPTION
i don't think we need this since it's what line 8 is doing:

```
    class << self
      attr_writer :logger
    end
...
    def self.logger=(logger)
      @logger = logger
    end
```
are dups


@miq-bot add_label cleanup