### PR TITLE
remove deprecated test reporter dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,12 @@ env:
   - RUBY_GC_HEAP_GROWTH_MAX_SLOTS=300000
   - RUBY_GC_HEAP_INIT_SLOTS=600000
   - RUBY_GC_HEAP_GROWTH_FACTOR=1.25
-after_script: bundle exec codeclimate-test-reporter
+before_script:
+- curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+- chmod +x ./cc-test-reporter
+- ./cc-test-reporter before-build
+after_script:
+- ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 notifications:
   webhooks:
     urls:

--- a/manageiq-appliance_console.gemspec
+++ b/manageiq-appliance_console.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rbnacl",                  ">= 3.2", "< 5.0"
 
   spec.add_development_dependency "bundler"
-  spec.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
```
Post-install message from codeclimate-test-reporter:

  Code Climate's codeclimate-test-reporter gem has been deprecated in favor of
  our language-agnostic unified test reporter. The new test reporter is faster,
  distributed as a static binary so dependency conflicts never occur, and
  supports parallelized CI builds & multi-language CI configurations.

  Please visit https://docs.codeclimate.com/v1.0/docs/configuring-test-coverage
  for help setting up your CI process with our new test reporter.
```

the token re: https://github.com/ManageIQ/azure-armrest/pull/403#issuecomment-754050779 got added last week

@miq-bot add_label dependencies, test 
@miq-bot assign @Fryguy 