### PR TITLE
Kafka cli

### DIFF
--- a/bin/appliance_console
+++ b/bin/appliance_console
@@ -425,8 +425,7 @@ Static Network Configuration
           say("#{selection}\n\n")
 
           message_server = MessageServerConfiguration.new
-          if message_server.ask_questions && message_server.activate
-            message_server.post_activation
+          if message_server.ask_questions && message_server.configure
             say("\nMessage Server configured successfully.\n")
             press_any_key
           else
@@ -439,7 +438,7 @@ Static Network Configuration
           say("#{selection}\n\n")
 
           message_client = MessageClientConfiguration.new
-          if message_client.ask_questions && message_client.activate
+          if message_client.ask_questions && message_client.configure
             say("\nMessage Client configured successfully.\n")
             press_any_key
           else

--- a/lib/manageiq/appliance_console/cli.rb
+++ b/lib/manageiq/appliance_console/cli.rb
@@ -187,21 +187,27 @@ module ApplianceConsole
         opt :oidc_unconfig,        "Unconfigure Appliance OpenID-Connect Authentication",            :type => :boolean, :default => false
         opt :server,               "{start|stop|restart} actions on evmserverd Server",   :type => :string
         opt :openscap,             "Setup OpenScap", :type => :boolean, :default => false
-        opt :message_server_config,       "Configure Appliance as a Kafka Message Server",               :type => :boolean, :default => false
-        opt :message_server_unconfig,     "Unconfigure Appliance as a Kafka Message Server",             :type => :boolean, :default => false
-        opt :message_client_config,       "Configure Appliance as a Kafka Message Client",               :type => :boolean, :default => false
-        opt :message_client_unconfig,     "Unconfigure Appliance as a Kafka Message Client",             :type => :boolean, :default => false
-        opt :message_keystore_username,   "Message Server Keystore Username",                            :type => :string
-        opt :message_keystore_password,   "Message Server Keystore Password",                            :type => :string
-        opt :message_server_username,     "Message Server Username",                                     :type => :string
-        opt :message_server_password,     "Message Server password",                                     :type => :string
-        opt :message_server_port,         "Message Server Port",                                         :type => :integer
-        opt :message_server_host,         "Message Server Hostname or IP Address",                       :type => :string
-        opt :message_truststore_path_src, "Message Server Truststore Path",                              :type => :string
-        opt :message_ca_cert_path_src,    "Message Server CA Cert Path",                                 :type => :string
+        opt :message_server_config,       "Subcommand to   Configure Appliance as a Kafka Message Server", :type => :boolean, :default => false
+        opt :message_server_unconfig,     "Subcommand to Unconfigure Appliance as a Kafka Message Server", :type => :boolean, :default => false
+        opt :message_client_config,       "Subcommand to   Configure Appliance as a Kafka Message Client", :type => :boolean, :default => false
+        opt :message_client_unconfig,     "Subcommand to Unconfigure Appliance as a Kafka Message Client", :type => :boolean, :default => false
+        opt :message_keystore_username,   "Message Server Keystore Username",                              :type => :string
+        opt :message_keystore_password,   "Message Server Keystore Password",                              :type => :string
+        opt :message_server_username,     "Message Server Username",                                       :type => :string
+        opt :message_server_password,     "Message Server password",                                       :type => :string
+        opt :message_server_port,         "Message Server Port",                                           :type => :integer
+        opt :message_server_host,         "Message Server Hostname or IP Address",                         :type => :string
+        opt :message_truststore_path_src, "Message Server Truststore Path",                                :type => :string
+        opt :message_ca_cert_path_src,    "Message Server CA Cert Path",                                   :type => :string
       end
       Optimist.die :region, "needed when setting up a local database" if region_number_required? && options[:region].nil?
+      Optimist.die "Supply only one of --message-server-config, --message-server-unconfig, --message-client-config or --message-client-unconfig" if multiple_message_subcommands?
       self
+    end
+
+    def multiple_message_subcommands?
+      a = [options[:message_server_config], options[:message_server_unconfig], options[:message_client_config], options[:message_client_unconfig]]
+      a.each_with_object(Hash.new(0)) { |o, h| h[o] += 1 }[true] > 1
     end
 
     def region_number_required?

--- a/lib/manageiq/appliance_console/cli.rb
+++ b/lib/manageiq/appliance_console/cli.rb
@@ -216,7 +216,7 @@ module ApplianceConsole
                               saml_config? || saml_unconfig? ||
                               oidc_config? || oidc_unconfig? ||
                               message_server_config? || message_server_unconfig? ||
-                              message_client_config? || message_client_config?
+                              message_client_config? || message_client_unconfig?
 
       if set_host?
         system_hosts = LinuxAdmin::Hosts.new
@@ -240,10 +240,10 @@ module ApplianceConsole
       oidc_unconfig if oidc_unconfig?
       set_server_state if set_server_state?
       openscap if openscap?
-      message_server_config if  message_server_config?
-      message_server_unconfig if  message_server_unconfig?
-      message_client_config if  message_client_config?
-      message_client_config if  message_client_config?
+      message_server_config if message_server_config?
+      message_server_unconfig if message_server_unconfig?
+      message_client_config if message_client_config?
+      message_client_unconfig if message_client_unconfig?
     rescue CliError => e
       say(e.message)
       say("")
@@ -446,19 +446,19 @@ module ApplianceConsole
     end
 
     def message_server_config
-      MessageServerConfiguration.new(options).activate
+      MessageServerConfiguration.new(options).configure
     end
 
     def message_server_unconfig
-      MessageServerConfiguration.new(options).deactivate
+      MessageServerConfiguration.new(options).unconfigure
     end
 
     def message_client_config
-      MessageClientConfiguration.new(options).activate
+      MessageClientConfiguration.new(options).configure
     end
 
-    def message_client_config
-      MessageClientConfiguration.new(options).deactivate
+    def message_client_unconfig
+      MessageClientConfiguration.new(options).unconfigure
     end
 
     def set_server_state

--- a/lib/manageiq/appliance_console/cli.rb
+++ b/lib/manageiq/appliance_console/cli.rb
@@ -199,7 +199,6 @@ module ApplianceConsole
         opt :message_server_host,         "Message Server Hostname or IP Address",                       :type => :string
         opt :message_truststore_path_src, "Message Server Truststore Path",                              :type => :string
         opt :message_ca_cert_path_src,    "Message Server CA Cert Path",                                 :type => :string
-
       end
       Optimist.die :region, "needed when setting up a local database" if region_number_required? && options[:region].nil?
       self

--- a/lib/manageiq/appliance_console/message_configuration.rb
+++ b/lib/manageiq/appliance_console/message_configuration.rb
@@ -84,6 +84,7 @@ module ManageIQ
       def unsecure_client_properties_content(algorithm, protocol)
         <<~CLIENT_PROPERTIES
           ssl.endpoint.identification.algorithm=#{algorithm}
+
           sasl.mechanism=PLAIN
           security.protocol=#{protocol}
           sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \\

--- a/lib/manageiq/appliance_console/message_configuration.rb
+++ b/lib/manageiq/appliance_console/message_configuration.rb
@@ -191,7 +191,7 @@ module ManageIQ
       end
 
       def secure?
-        server_port == 9_093
+        message_server_port == 9_093
       end
     end
   end

--- a/lib/manageiq/appliance_console/message_configuration.rb
+++ b/lib/manageiq/appliance_console/message_configuration.rb
@@ -126,7 +126,7 @@ module ManageIQ
 
       def valid_environment?
         if already_configured?
-          deactivate if agree("\nAlready configured on this Appliance, Un-Configure first? (Y/N): ")
+          unconfigure if agree("\nAlready configured on this Appliance, Un-Configure first? (Y/N): ")
           return false unless agree("\nProceed with Configuration? (Y/N): ")
         end
         true
@@ -184,7 +184,7 @@ module ManageIQ
         evmserverd_service.restart if evmserverd_service.running?
       end
 
-      def deactivate
+      def unconfigure
         configure_messaging_type("miq_queue") # Settings.prototype.messaging_type = 'miq_queue'
         restart_evmserverd
         remove_installed_files

--- a/lib/manageiq/appliance_console/message_configuration_client.rb
+++ b/lib/manageiq/appliance_console/message_configuration_client.rb
@@ -22,7 +22,7 @@ module ManageIQ
         @installed_files = [client_properties_path, messaging_yaml_path, truststore_path]
       end
 
-      def activate
+      def configure
         begin
           configure_messaging_yaml          # Set up the local message client in case EVM is actually running on this, Message Server
           create_client_properties          # Create the client.properties configuration fle

--- a/lib/manageiq/appliance_console/message_configuration_client.rb
+++ b/lib/manageiq/appliance_console/message_configuration_client.rb
@@ -7,7 +7,8 @@ require "manageiq/appliance_console/message_configuration"
 module ManageIQ
   module ApplianceConsole
     class MessageClientConfiguration < MessageConfiguration
-      attr_reader :message_server_password, :message_server_username, :installed_files
+      attr_reader :message_server_password, :message_server_username, :installed_files,
+                  :message_truststore_path_src, :message_ca_cert_path_src
 
       def initialize(options = {})
         super(options)

--- a/lib/manageiq/appliance_console/message_configuration_client.rb
+++ b/lib/manageiq/appliance_console/message_configuration_client.rb
@@ -7,14 +7,17 @@ require "manageiq/appliance_console/message_configuration"
 module ManageIQ
   module ApplianceConsole
     class MessageClientConfiguration < MessageConfiguration
-      attr_reader :server_password, :server_username, :installed_files
+      attr_reader :message_server_password, :message_server_username, :installed_files
 
       def initialize(options = {})
         super(options)
 
-        @server_host     = options[:server_host]
-        @server_username = options[:server_usernamed] || "root"
-        @server_password = options[:server_password]
+        @message_server_host         = options[:message_server_host]
+        @message_server_username     = options[:message_server_usernamed] || "root"
+        @message_server_password     = options[:message_server_password]
+
+        @message_truststore_path_src = options[:message_truststore_path_src] || truststore_path
+        @message_ca_cert_path_src    = options[:message_ca_cert_path_src] || ca_cert_path
 
         @installed_files = [client_properties_path, messaging_yaml_path, truststore_path]
       end
@@ -42,35 +45,34 @@ module ManageIQ
       def ask_for_parameters
         say("\nMessage Client Parameters:\n\n")
 
-        @server_host         = ask_for_string("Message Server Hostname or IP address")
-        @server_port         = ask_for_integer("Message Server Port number", (1..65_535), 9_093).to_i
-        @server_username     = ask_for_string("Message Server Username", server_username)
-        @server_password     = ask_for_password("Message Server Password")
-        @truststore_path_src = ask_for_string("Message Server Truststore Path", truststore_path)
-        @ca_cert_path_src    = ask_for_string("Message Server CA Cert Path", ca_cert_path)
-
-        @username  = ask_for_string("Message Key Username", username) if secure?
-        @password  = ask_for_password("Message Key Password") if secure?
+        @message_server_host         = ask_for_string("Message Server Hostname or IP address")
+        @message_server_port         = ask_for_integer("Message Server Port number", (1..65_535), 9_093).to_i
+        @message_server_username     = ask_for_string("Message Server Username", message_server_username)
+        @message_server_password     = ask_for_password("Message Server Password")
+        @message_truststore_path_src = ask_for_string("Message Server Truststore Path", truststore_path)
+        @message_ca_cert_path_src    = ask_for_string("Message Server CA Cert Path", ca_cert_path)
+        @message_keystore_username   = ask_for_string("Message Keystore Username", message_keystore_username) if secure?
+        @message_keystore_password   = ask_for_password("Message Keystore Password") if secure?
       end
 
       def show_parameters
         say("\nMessage Client Configuration:\n")
         say("Message Client Details:\n")
-        say("  Message Server Hostname:   #{server_host}\n")
-        say("  Message Server Username:   #{server_username}\n")
-        say("  Message Key Username:      #{username}\n")
+        say("  Message Server Hostname:   #{message_server_host}\n")
+        say("  Message Server Username:   #{message_server_username}\n")
+        say("  Message Keystore Username: #{message_keystore_username}\n")
       end
 
       def fetch_truststore_from_server
         say(__method__.to_s.tr("_", " ").titleize)
 
-        fetch_from_server(truststore_path, truststore_path)
+        fetch_from_server(message_truststore_path_src, truststore_path)
       end
 
       def fetch_ca_cert_from_server
         say(__method__.to_s.tr("_", " ").titleize)
 
-        fetch_from_server(ca_cert_path_src, ca_cert_path)
+        fetch_from_server(message_ca_cert_path_src, ca_cert_path)
       end
 
       private
@@ -78,7 +80,7 @@ module ManageIQ
       def fetch_from_server(src_file, dst_file)
         return if file_found?(dst_file)
 
-        Net::SCP.start(server_host, server_username, :password => server_password) do |scp|
+        Net::SCP.start(message_server_host, message_server_username, :password => message_server_password) do |scp|
           scp.download!(src_file, dst_file)
         end
 

--- a/lib/manageiq/appliance_console/message_configuration_server.rb
+++ b/lib/manageiq/appliance_console/message_configuration_server.rb
@@ -78,6 +78,13 @@ module ManageIQ
         say("  Message Keystore Username: #{message_keystore_username}\n")
       end
 
+      def unconfigure
+        super
+
+        unconfigure_firewall
+        deactivate_services
+      end
+
       private
 
       def my_hostname
@@ -179,13 +186,6 @@ module ManageIQ
 
         FileUtils.cp(server_properties_sample_path, server_properties_path)
         File.write(server_properties_path, content, :mode => "a")
-      end
-
-      def unconfigure
-        super
-
-        unconfigure_firewall
-        deactivate_services
       end
 
       def unconfigure_firewall

--- a/lib/manageiq/appliance_console/message_configuration_server.rb
+++ b/lib/manageiq/appliance_console/message_configuration_server.rb
@@ -29,7 +29,7 @@ module ManageIQ
         @installed_files = [jaas_config_path, client_properties_path, server_properties_path, messaging_yaml_path, LOGS_DIR] + keystore_files
       end
 
-      def activate
+      def configure
         begin
           create_jaas_config                # Create the message server jaas config file
           create_client_properties          # Create the client.properties config
@@ -39,6 +39,7 @@ module ManageIQ
           create_server_properties          # Update the /opt/message/config/server.properties
           configure_messaging_yaml          # Set up the local message client in case EVM is actually running on this, Message Server
           configure_messaging_type("kafka") # Settings.prototype.messaging_type = 'kafka'
+          restart_services
         rescue AwesomeSpawn::CommandResultError => e
           say(e.result.output)
           say(e.result.error)
@@ -52,7 +53,7 @@ module ManageIQ
         true
       end
 
-      def post_activation
+      def restart_services
         say("Starting zookeeper and configure it to start on reboots ...")
         LinuxAdmin::Service.new("zookeeper").start.enable
 
@@ -180,7 +181,7 @@ module ManageIQ
         File.write(server_properties_path, content, :mode => "a")
       end
 
-      def deactivate
+      def unconfigure
         super
 
         unconfigure_firewall

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -5,6 +5,22 @@ describe ManageIQ::ApplianceConsole::Cli do
     it "fails if a region is not specified for a local database" do
       expect { subject.parse(%w(--internal)) }.to raise_error(OptimistDieSpecError)
     end
+
+    it "fails if multiple message subcommands are specified" do
+      expect { subject.parse(%w[--message-server-config --message-client-config]) }.to raise_error(OptimistDieSpecError)
+    end
+
+    it "fails if message server config and unconfig subcommands are specified" do
+      expect { subject.parse(%w[--message-server-config --message-server-unconfig]) }.to raise_error(OptimistDieSpecError)
+    end
+
+    it "fails if message client config and unconfig subcommands are specified" do
+      expect { subject.parse(%w[--message-client-config --message-client-unconfig]) }.to raise_error(OptimistDieSpecError)
+    end
+
+    it "fails if all message subcommands are specified" do
+      expect { subject.parse(%w[--message-server-config --message-server-unconfig --message-client-config --message-client-unconfig]) }.to raise_error(OptimistDieSpecError)
+    end
   end
 
   describe "#run" do

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -704,6 +704,17 @@ describe ManageIQ::ApplianceConsole::Cli do
     end
   end
 
+  context "Configuring Message Server" do
+    it "should pass the arguments to and activate the hconfigure Message Server" do
+      message_server = double
+      expect(message_server).to receive(:activate)
+      expect(ManageIQ::ApplianceConsole::MessageServerConfiguration).to receive(:new)
+        .with(hash_including(:message_server_host => "server.example.com", :message_keystore_username => "user", :message_keystore_password => "pass"))
+        .and_return(message_server)
+      subject.parse(%w[--message-server-config --message-server-host server.example.com --message-keystore-username user --message-keystore-password pass]).run
+    end
+  end
+
   private
 
   def expect_v2_key(exists = true)

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -704,14 +704,51 @@ describe ManageIQ::ApplianceConsole::Cli do
     end
   end
 
-  context "Configuring Message Server" do
-    it "should pass the arguments to and activate the hconfigure Message Server" do
+  context "#message_server_config" do
+    it "should initiate Message Server config" do
       message_server = double
-      expect(message_server).to receive(:activate)
+      expect(message_server).to receive(:configure)
       expect(ManageIQ::ApplianceConsole::MessageServerConfiguration).to receive(:new)
         .with(hash_including(:message_server_host => "server.example.com", :message_keystore_username => "user", :message_keystore_password => "pass"))
         .and_return(message_server)
       subject.parse(%w[--message-server-config --message-server-host server.example.com --message-keystore-username user --message-keystore-password pass]).run
+    end
+  end
+
+  context "#message_server_unconfig" do
+    it "should initiate Message Server unconfig" do
+      message_server = double
+      expect(message_server).to receive(:unconfigure)
+      expect(ManageIQ::ApplianceConsole::MessageServerConfiguration).to receive(:new).and_return(message_server)
+      subject.parse(%w[--message-server-unconfig]).run
+    end
+  end
+
+  context "#message_client_config" do
+    it "should initiate Message Client config" do
+      message_client = double
+      expect(message_client).to receive(:configure)
+      expect(ManageIQ::ApplianceConsole::MessageClientConfiguration).to receive(:new)
+        .with(hash_including(:message_server_host       => "server.example.com",
+                             :message_server_username   => "root",
+                             :message_server_password   => "smartvm",
+                             :message_keystore_username => "user",
+                             :message_keystore_password => "pass")).and_return(message_client)
+      subject.parse(%w[--message-client-config
+                       --message-server-host server.example.com
+                       --message-server-username root
+                       --message-server-password smartvm
+                       --message-keystore-username user
+                       --message-keystore-password pass]).run
+    end
+  end
+
+  context "#message_client_unconfig" do
+    it "should initiate Message Client unconfig" do
+      message_client = double
+      expect(message_client).to receive(:unconfigure)
+      expect(ManageIQ::ApplianceConsole::MessageClientConfiguration).to receive(:new).and_return(message_client)
+      subject.parse(%w[--message-client-unconfig]).run
     end
   end
 

--- a/spec/message_configuration_client_spec.rb
+++ b/spec/message_configuration_client_spec.rb
@@ -1,18 +1,18 @@
 require 'tempfile'
 
 describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
-  let(:server_host) { "my-kafka-server.example.com" }
-  let(:server_username) { "root" }
-  let(:server_password) { "server_super_secret" }
-  let(:username) { "admin" }
-  let(:password) { "super_secret" }
+  let(:message_server_host) { "my-kafka-server.example.com" }
+  let(:message_server_username) { "root" }
+  let(:message_server_password) { "server_super_secret" }
+  let(:message_keystore_username) { "admin" }
+  let(:message_keystore_password) { "super_secret" }
   subject do
-    described_class.new(:server_host     => server_host,
-                        :server_port     => 9_093,
-                        :server_username => server_username,
-                        :server_password => server_password,
-                        :username        => username,
-                        :password        => password)
+    described_class.new(:message_server_host       => message_server_host,
+                        :message_server_port       => 9_093,
+                        :message_server_username   => message_server_username,
+                        :message_server_password   => message_server_password,
+                        :message_keystore_username => message_keystore_username,
+                        :message_keystore_password => message_keystore_password)
   end
 
   before do
@@ -41,15 +41,15 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
       allow(subject).to receive(:message_client_configured?).and_return(false)
     end
 
-    it "should prompt for username and password" do
+    it "should prompt for message_keystore_username and message_keystore_password" do
       expect(subject).to receive(:ask_for_string).with("Message Server Hostname or IP address").and_return("my-host-name.example.com")
       expect(subject).to receive(:ask_for_integer).with("Message Server Port number", (1..65_535), 9_093).and_return("9093")
-      expect(subject).to receive(:ask_for_string).with("Message Key Username", username).and_return("admin")
-      expect(subject).to receive(:ask_for_password).with("Message Key Password").and_return("top_secret")
+      expect(subject).to receive(:ask_for_string).with("Message Keystore Username", message_keystore_username).and_return("admin")
+      expect(subject).to receive(:ask_for_password).with("Message Keystore Password").and_return("top_secret")
       expect(subject).to receive(:ask_for_string).with("Message Server Truststore Path", subject.truststore_path)
       expect(subject).to receive(:ask_for_string).with("Message Server CA Cert Path", subject.ca_cert_path)
 
-      expect(subject).to receive(:ask_for_string).with("Message Server Username", server_username).and_return("root")
+      expect(subject).to receive(:ask_for_string).with("Message Server Username", message_server_username).and_return("root")
       expect(subject).to receive(:ask_for_password).with("Message Server Password").and_return("top_secret")
 
       expect(subject).to receive(:say).at_least(5).times
@@ -60,12 +60,12 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
     it "should display Server Hostname and Key Username" do
       allow(subject).to receive(:ask_for_string).with("Message Server Hostname or IP address").and_return("my-kafka-server.example.com")
       allow(subject).to receive(:ask_for_integer).with("Message Server Port number", (1..65_535), 9_093).and_return("9093")
-      allow(subject).to receive(:ask_for_string).with("Message Key Username", username).and_return("admin")
-      allow(subject).to receive(:ask_for_password).with("Message Key Password").and_return("top_secret")
+      allow(subject).to receive(:ask_for_string).with("Message Keystore Username", message_keystore_username).and_return("admin")
+      allow(subject).to receive(:ask_for_password).with("Message Keystore Password").and_return("top_secret")
       allow(subject).to receive(:ask_for_string).with("Message Server Truststore Path", subject.truststore_path)
       allow(subject).to receive(:ask_for_string).with("Message Server CA Cert Path", subject.ca_cert_path)
 
-      allow(subject).to receive(:ask_for_string).with("Message Server Username", server_username).and_return("root")
+      allow(subject).to receive(:ask_for_string).with("Message Server Username", message_server_username).and_return("root")
       allow(subject).to receive(:ask_for_password).with("Message Server Password").and_return("top_secret")
 
       expect(subject).to receive(:say).with("\nMessage Client Parameters:\n\n")
@@ -73,7 +73,7 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
       expect(subject).to receive(:say).with("Message Client Details:\n")
       expect(subject).to receive(:say).with("  Message Server Hostname:   my-kafka-server.example.com\n")
       expect(subject).to receive(:say).with("  Message Server Username:   root\n")
-      expect(subject).to receive(:say).with("  Message Key Username:      admin\n")
+      expect(subject).to receive(:say).with("  Message Keystore Username: admin\n")
 
       expect(subject.send(:ask_questions)).to be_truthy
     end
@@ -81,12 +81,12 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
 
   describe "#create_client_properties" do
     subject do
-      described_class.new(:server_host     => server_host,
-                          :server_port     => server_port,
-                          :server_username => server_username,
-                          :server_password => server_password,
-                          :username        => username,
-                          :password        => password)
+      described_class.new(:message_server_host       => message_server_host,
+                          :message_server_port       => message_server_port,
+                          :message_server_username   => message_server_username,
+                          :message_server_password   => message_server_password,
+                          :message_keystore_username => message_keystore_username,
+                          :message_keystore_password => message_keystore_password)
     end
 
     let(:secure_content) do
@@ -95,10 +95,10 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
         sasl.mechanism=PLAIN
         security.protocol=#{security_protocol}
         sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \\
-          username=#{username} \\
-          password=#{password} ;
+          username=#{message_keystore_username} \\
+          password=#{message_keystore_password} ;
         ssl.truststore.location=#{subject.truststore_path}
-        ssl.truststore.password=#{password}
+        ssl.truststore.password=#{message_keystore_password}
       CLIENT_PROPERTIES
     end
 
@@ -108,8 +108,8 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
         sasl.mechanism=PLAIN
         security.protocol=#{security_protocol}
         sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \\
-          username=#{username} \\
-          password=#{password} ;
+          username=#{message_keystore_username} \\
+          password=#{message_keystore_password} ;
       CLIENT_PROPERTIES
     end
 
@@ -137,8 +137,8 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
     end
 
     context "secure with hostname" do
-      let(:server_port) { 9_093 }
-      let(:server_host) { "my-kafka-server.example.com" }
+      let(:message_server_port) { 9_093 }
+      let(:message_server_host) { "my-kafka-server.example.com" }
       let(:ident_algorithm) { "HTTPS" }
       let(:security_protocol) { "SASL_SSL" }
       let(:content) { secure_content }
@@ -147,8 +147,8 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
     end
 
     context "secure with IP address" do
-      let(:server_port) { 9_093 }
-      let(:server_host) { "192.0.2.0" }
+      let(:message_server_port) { 9_093 }
+      let(:message_server_host) { "192.0.2.0" }
       let(:ident_algorithm) { "" }
       let(:security_protocol) { "SASL_SSL" }
       let(:content) { secure_content }
@@ -157,8 +157,8 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
     end
 
     context "unsecure with hostname" do
-      let(:server_port) { 9_092 }
-      let(:server_host) { "my-kafka-server.example.com" }
+      let(:message_server_port) { 9_092 }
+      let(:message_server_host) { "my-kafka-server.example.com" }
       let(:ident_algorithm) { "HTTPS" }
       let(:security_protocol) { "PLAINTEXT" }
       let(:content) { unsecure_content }
@@ -167,8 +167,8 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
     end
 
     context "unsecure with IP address" do
-      let(:server_port) { 9_092 }
-      let(:server_host) { "192.0.2.0" }
+      let(:message_server_port) { 9_092 }
+      let(:message_server_host) { "192.0.2.0" }
       let(:ident_algorithm) { "" }
       let(:security_protocol) { "PLAINTEXT" }
       let(:content) { unsecure_content }
@@ -179,12 +179,12 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
 
   describe "#configure_messaging_yaml" do
     subject do
-      described_class.new(:server_host     => server_host,
-                          :server_port     => server_port,
-                          :server_username => server_username,
-                          :server_password => server_password,
-                          :username        => username,
-                          :password        => password)
+      described_class.new(:message_server_host       => message_server_host,
+                          :message_server_port       => message_server_port,
+                          :message_server_username   => message_server_username,
+                          :message_server_password   => message_server_password,
+                          :message_keystore_username => message_keystore_username,
+                          :message_keystore_password => message_keystore_password)
     end
 
     let(:messagine_kafka_yml_content) do
@@ -290,13 +290,13 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
 
     context "when using secure port 9093" do
       let(:content) { secure_messagine_yml_content }
-      let(:server_port) { 9_093 }
+      let(:message_server_port) { 9_093 }
       include_examples "messaging yaml file"
     end
 
     context "when using unsecure port 9092" do
       let(:content) { unsecure_messagine_yml_content }
-      let(:server_port) { 9_092 }
+      let(:message_server_port) { 9_092 }
       include_examples "messaging yaml file"
     end
   end
@@ -309,7 +309,7 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
     it "fetches the truststore from the server" do
       scp = double('scp')
       expect(scp).to receive(:download!).with(subject.truststore_path, subject.truststore_path).and_return(:result)
-      expect(Net::SCP).to receive(:start).with(server_host, server_username, :password => server_password).and_yield(scp).and_return(true)
+      expect(Net::SCP).to receive(:start).with(message_server_host, message_server_username, :password => message_server_password).and_yield(scp).and_return(true)
       subject.send(:fetch_truststore_from_server)
     end
 

--- a/spec/message_configuration_client_spec.rb
+++ b/spec/message_configuration_client_spec.rb
@@ -92,6 +92,7 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
     let(:secure_content) do
       <<~CLIENT_PROPERTIES
         ssl.endpoint.identification.algorithm=#{ident_algorithm}
+
         sasl.mechanism=PLAIN
         security.protocol=#{security_protocol}
         sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \\
@@ -105,6 +106,7 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
     let(:unsecure_content) do
       <<~CLIENT_PROPERTIES
         ssl.endpoint.identification.algorithm=#{ident_algorithm}
+
         sasl.mechanism=PLAIN
         security.protocol=#{security_protocol}
         sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \\


### PR DESCRIPTION
This PR will enable kafka server and client configuration from the `appliance_console_cli`

**NOTE:** This PR must not be merged until PR: https://github.com/ManageIQ/manageiq-appliance_console/pull/149 has been merged.
 
Fixes https://github.com/ManageIQ/manageiq-appliance_console/issues/142

**Four subcommands are added:**
```
  --message-server-config                Configure Appliance as a Kafka Message Server
  --message-server-unconfig              Unconfigure Appliance as a Kafka Message Server
  --message-client-config                Configure Appliance as a Kafka Message Client
  --message-client-unconfig              Unconfigure Appliance as a Kafka Message Client
``` 

and the following parameters are added to support the new subcommands.

```
 --message-keystore-username=<s>         Message Server Keystore Username
  --message-keystore-password=<s>        Message Server Keystore Password
  --message-server-username=<s>          Message Server Username
  --message-server-password=<s>          Message Server password
  --message-server-port=<i>              Message Server Port
  --message-server-host=<s>              Message Server Hostname or IP Address
  --message-truststore-path-src=<s>      Message Server Truststore Path
  --message-ca-cert-path-src=<s>         Message Server CA Cert Path
```

**In addition to this new functionality the no longer used `messaging_configuration` has been removed.**

**Some refactoring was done to better align with CLI usage**.

- activate and deactivate have been renamed to configure and unconfigure
- the following variables have been renamed accordingly:

```
server_username       -> message_server_username      
server_password       -> message_server_password      
       username       -> message_keystore_username    
       password       -> message_keystore_password    
server_port           -> message_server_port          
server_host           -> message_server_host
server_host_is_ipaddr -> message_server_host_is_ipaddr
```

**Example usage:**

```
# Run on the kafka-server
kafka-server> appliance_console_cli --message-server-unconfig
kafka-server> appliance_console_cli --message-server-config \
                                    --message-keystore-username="admin" \
                                    --message-keystore-password="topsecret"

# Run on the kafka-client
kafka-client> appliance_console_cli --message-client-unconfig
kafka-client> appliance_console_cli --message-client-config \
                                    --message-server-host="kafka-server.example.com" \
                                    --message-server-username="root" \
                                    --message-server-password="topsecret" \
                                    --message-keystore-username="admin" \
                                    --message-keystore-password="topsecret"

```