### PR TITLE
Use stdin data for pw

### DIFF
--- a/spec/message_configuration_server_spec.rb
+++ b/spec/message_configuration_server_spec.rb
@@ -133,16 +133,14 @@ describe ManageIQ::ApplianceConsole::MessageServerConfiguration do
         allow(AwesomeSpawn).to receive(:run!).exactly(7).times
 
         expect(AwesomeSpawn).to receive(:run!)
-          .with("keytool",
-                :params => {"-keystore"  => @keystore_path,
-                            "-validity"  => 10_000,
-                            "-genkey"    => nil,
-                            "-keyalg"    => "RSA",
-                            "-storepass" => message_keystore_password,
-                            "-keypass"   => message_keystore_password,
-                            "-alias"     => ks_alias,
-                            "-dname"     => "cn=#{ks_alias}",
-                            "-ext"       => ext})
+          .with("keytool", :params     => {"-keystore" => @keystore_path,
+                                           "-validity" => 10_000,
+                                           "-genkey"   => nil,
+                                           "-keyalg"   => "RSA",
+                                           "-alias"    => ks_alias,
+                                           "-dname"    => "cn=#{ks_alias}",
+                                           "-ext"      => ext},
+                           :stdin_data => "#{message_keystore_password}\n#{message_keystore_password}\n\n")
         expect(subject.send(:configure_keystore)).to be_nil
         expect(File.directory?(subject.keystore_dir_path)).to be_truthy
       end


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-appliance_console/issues/140

Note: To isolate the changes for this PR see URL:
https://github.com/jvlcek/manageiq-appliance_console/compare/kafka_cli...jvlcek:use_stdin_data_for_pw

NOTE: This PR is built on top of  PR: https://github.com/ManageIQ/manageiq-appliance_console/pull/151 which must be merged before this PR. 
This PR avoids passing passwords on the command line by leverage AwesomeSpawn's :stdin_data.

Each of the keytool commands has a slightly different requirement for stdin which I note in comments.