### PR TITLE
When configuring the kafka client disable the server

### DIFF
--- a/lib/manageiq/appliance_console/message_configuration_client.rb
+++ b/lib/manageiq/appliance_console/message_configuration_client.rb
@@ -25,6 +25,7 @@ module ManageIQ
 
       def configure
         begin
+          MessageServerConfiguration.new.unconfigure if MessageServerConfiguration.configured?
           configure_messaging_yaml          # Set up the local message client in case EVM is actually running on this, Message Server
           create_client_properties          # Create the client.properties configuration fle
           fetch_truststore_from_server      # Fetch the Java Keystore from the Kafka Server

--- a/lib/manageiq/appliance_console/message_configuration_server.rb
+++ b/lib/manageiq/appliance_console/message_configuration_server.rb
@@ -85,6 +85,11 @@ module ManageIQ
         deactivate_services
       end
 
+      def self.configured?
+        LinuxAdmin::Service.new("kafka").running? ||
+          LinuxAdmin::Service.new("zookeeper").running?
+      end
+
       private
 
       def my_hostname

--- a/spec/message_configuration_server_spec.rb
+++ b/spec/message_configuration_server_spec.rb
@@ -294,5 +294,18 @@ describe ManageIQ::ApplianceConsole::MessageServerConfiguration do
 
       expect(described_class.configured?).to be_truthy
     end
+
+    it "returns false if neither the zookeeper service or the kafka service are running" do
+      kafka = LinuxAdmin::Service.new("kafka")
+      expect(kafka).to receive(:running?).and_return(false)
+
+      zookeeper = LinuxAdmin::Service.new("zookeeper")
+      expect(zookeeper).to receive(:running?).and_return(false)
+
+      expect(LinuxAdmin::Service).to receive(:new).with("zookeeper").and_return(zookeeper)
+      expect(LinuxAdmin::Service).to receive(:new).with("kafka").and_return(kafka)
+
+      expect(described_class.configured?).not_to be_truthy
+    end
   end
 end

--- a/spec/message_configuration_server_spec.rb
+++ b/spec/message_configuration_server_spec.rb
@@ -272,4 +272,27 @@ describe ManageIQ::ApplianceConsole::MessageServerConfiguration do
       subject.send(:restart_services)
     end
   end
+
+  describe "#configured?" do
+    it "returns true if the kafka service is running" do
+      kafka = LinuxAdmin::Service.new("kafka")
+      expect(kafka).to receive(:running?).and_return(true)
+      expect(LinuxAdmin::Service).to receive(:new).with("kafka").and_return(kafka)
+
+      expect(described_class.configured?).to be_truthy
+    end
+
+    it "returns true if the zookeeper service is running even if kafka is not" do
+      kafka = LinuxAdmin::Service.new("kafka")
+      expect(kafka).to receive(:running?).and_return(false)
+
+      zookeeper = LinuxAdmin::Service.new("zookeeper")
+      expect(zookeeper).to receive(:running?).and_return(true)
+
+      expect(LinuxAdmin::Service).to receive(:new).with("zookeeper").and_return(zookeeper)
+      expect(LinuxAdmin::Service).to receive(:new).with("kafka").and_return(kafka)
+
+      expect(described_class.configured?).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-appliance_console/issues/141

The overhead imposed by running the kafka server is unnecessary when only the kafka client is desired.

The best way to ensure resources used by the kafka server are cleaned up is to invoke the kafka servers `#unconfigure` method. Running the `#unconfigure` method is only necessary if the kafka or zookeeper services are not running. It could be argued that the new method `#configured?` only need check if the kafka service is running but to be safe I check if either kafka or zooker services are running.