### PR TITLE
Move the kafka persistent message storage to a dedicated disk

### DIFF
--- a/lib/manageiq/appliance_console/cli.rb
+++ b/lib/manageiq/appliance_console/cli.rb
@@ -199,6 +199,7 @@ module ApplianceConsole
         opt :message_server_host,         "Message Server Hostname or IP Address",                         :type => :string
         opt :message_truststore_path_src, "Message Server Truststore Path",                                :type => :string
         opt :message_ca_cert_path_src,    "Message Server CA Cert Path",                                   :type => :string
+        opt :message_persistent_disk,     "Message Persistent Disk Path",                                  :type => :string
       end
       Optimist.die :region, "needed when setting up a local database" if region_number_required? && options[:region].nil?
       Optimist.die "Supply only one of --message-server-config, --message-server-unconfig, --message-client-config or --message-client-unconfig" if multiple_message_subcommands?

--- a/lib/manageiq/appliance_console/message_configuration_server.rb
+++ b/lib/manageiq/appliance_console/message_configuration_server.rb
@@ -11,7 +11,7 @@ module ManageIQ
                   :ca_cert_srl_path, :ca_key_path, :cert_file_path, :cert_signed_path,
                   :keystore_files, :installed_files, :message_persistent_disk
 
-      PERSISTENT_DIRECTORY = Pathname.new("/var/lib/kafka_persistent_data").freeze
+      PERSISTENT_DIRECTORY = Pathname.new("/var/lib/kafka/persistent_data").freeze
       PERSISTENT_NAME = "kafka_messages".freeze
 
       def initialize(options = {})

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -729,6 +729,15 @@ describe ManageIQ::ApplianceConsole::Cli do
         .and_return(message_server)
       subject.parse(%w[--message-server-config --message-server-host server.example.com --message-keystore-username user --message-keystore-password pass]).run
     end
+
+    it "should initiate Message Server config with persistent disk" do
+      message_server = double
+      expect(message_server).to receive(:configure)
+      expect(ManageIQ::ApplianceConsole::MessageServerConfiguration).to receive(:new)
+        .with(hash_including(:message_server_host => "server.example.com", :message_keystore_username => "user", :message_keystore_password => "pass", :message_persistent_disk => "/dev/test"))
+        .and_return(message_server)
+      subject.parse(%w[--message-server-config --message-server-host server.example.com --message-keystore-username user --message-keystore-password pass --message-persistent-disk /dev/test]).run
+    end
   end
 
   context "#message_server_unconfig" do


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-appliance_console/issues/143

This PR allows the administrator to optionally move the kafka persistent message storage to a dedicated disk volume.
Kafka maintains the persistent message storage on the file system under the directory specified by the `log.dirs` parameter as set in the `server.properties` file. Kafka also keeps track of what `log.dirs` was set to. If `log.dirs` is updated kafka will migrate the persistent messages to the new location.

If the mount point for the new dedicated disk volume is the same as the old value for `log.dirs` kafka fails to restart because the old persistent message store is hidden by the new, `empty` mount point. An effective work around for this it to direct the new mount point for the dedicated disk volume to a different directory and to update the `log.dirs` parameter in the `server.properties` file to point to the new directory. This approach has the added benefit that kafka will migrate the old persistent message store to the new location Since we plan to configure kafka on first boot it is highly likely the this automatic migration will be valuable.
