### PR TITLE
[WIP] make v2_key private

### DIFF
--- a/lib/manageiq/appliance_console/database_configuration.rb
+++ b/lib/manageiq/appliance_console/database_configuration.rb
@@ -275,7 +275,7 @@ FRIENDLY
 
     def do_save(settings)
       require 'yaml'
-      File.write(DB_YML, YAML.dump(settings))
+      File.write(DB_YML, YAML.dump(settings), :perm => 0o440)
     end
 
     def initialize_from_hash(hash)

--- a/lib/manageiq/appliance_console/key_configuration.rb
+++ b/lib/manageiq/appliance_console/key_configuration.rb
@@ -73,7 +73,7 @@ module ApplianceConsole
         say("Failed to overwrite original key, original key kept. #{e.message}")
         return false
       end
-      FileUtils.chmod(0o400, KEY_FILE)
+      File.chmod(0o440, KEY_FILE)
     end
 
     def remove_new_key_if_any

--- a/spec/key_configuration_spec.rb
+++ b/spec/key_configuration_spec.rb
@@ -62,7 +62,7 @@ describe ManageIQ::ApplianceConsole::KeyConfiguration do
           v2_exists(true)  # after downloaded
           expect(Net::SCP).to receive(:start).with(host, "root", :password => password)
           expect(FileUtils).to receive(:mv).with(/v2_key\.tmp/, /v2_key$/, :force=>true).and_return(true)
-          expect(FileUtils).to receive(:chmod).with(0o400, /v2_key/).and_return(["v2_key"])
+          expect(File).to receive(:chmod).with(0o440, /v2_key/).and_return(["v2_key"])
           expect(subject.activate).to be_truthy
         end
 
@@ -71,7 +71,7 @@ describe ManageIQ::ApplianceConsole::KeyConfiguration do
           v2_exists(false)
           expect(ManageIQ::Password).to receive(:generate_symmetric).and_return(154)
           expect(FileUtils).to receive(:mv).with(/v2_key\.tmp/, /v2_key$/, :force=>true).and_return(true)
-          expect(FileUtils).to receive(:chmod).with(0o400, /v2_key/).and_return(["v2_key"])
+          expect(File).to receive(:chmod).with(0o440, /v2_key/).and_return(["v2_key"])
           expect(subject.activate).to be_truthy
         end
       end
@@ -85,7 +85,7 @@ describe ManageIQ::ApplianceConsole::KeyConfiguration do
           expect(scp).to receive(:download!).with(subject.key_path, /v2_key/).and_return(:result)
           expect(Net::SCP).to receive(:start).with(host, "root", :password => password).and_yield(scp).and_return(true)
           expect(FileUtils).to receive(:mv).with(/v2_key\.tmp/, /v2_key$/, :force=>true).and_return(true)
-          expect(FileUtils).to receive(:chmod).with(0o400, /v2_key/).and_return(["v2_key"])
+          expect(File).to receive(:chmod).with(0o440, /v2_key/).and_return(["v2_key"])
           expect(subject.activate).to be_truthy
         end
 


### PR DESCRIPTION
not a dependent, but also note we are setting the permissions elsewhere as well as a backup https://github.com/ManageIQ/manageiq-password/pull/22

chmod `v2_key` and `database.yml` so it is accessible by root and manageiq user.
The directory has a `SGID` bit so the files are accessible by manageiq via the group.

~~see also https://github.com/ManageIQ/manageiq/pull/21248~~
