### PR TITLE
Chown database.yml as manageiq:manageiq

### DIFF
--- a/lib/manageiq/appliance_console/database_configuration.rb
+++ b/lib/manageiq/appliance_console/database_configuration.rb
@@ -275,7 +275,10 @@ FRIENDLY
 
     def do_save(settings)
       require 'yaml'
-      File.write(DB_YML, YAML.dump(settings))
+      File.open(DB_YML, "w") do |f|
+        f.write(YAML.dump(settings))
+        f.chown(manageiq_uid, manageiq_gid)
+      end
     end
 
     def initialize_from_hash(hash)
@@ -288,6 +291,14 @@ FRIENDLY
           raise ArgumentError, "Invalid argument: #{k}"
         end
       end
+    end
+
+    def manageiq_uid
+      @manageiq_uid ||= Process::UID.from_name("manageiq")
+    end
+
+    def manageiq_gid
+      @manageiq_gid ||= Process::GID.from_name("manageiq")
     end
   end
 end

--- a/lib/manageiq/appliance_console/database_configuration.rb
+++ b/lib/manageiq/appliance_console/database_configuration.rb
@@ -5,9 +5,13 @@ require 'manageiq-password'
 require 'pathname'
 require 'fileutils'
 
+require_relative './manageiq_user_mixin'
+
 module ManageIQ
 module ApplianceConsole
   class DatabaseConfiguration
+    include ManageIQ::ApplianceConsole::ManageiqUserMixin
+
     attr_accessor :adapter, :host, :username, :database, :port, :region
     attr_reader :password
 
@@ -291,14 +295,6 @@ FRIENDLY
           raise ArgumentError, "Invalid argument: #{k}"
         end
       end
-    end
-
-    def manageiq_uid
-      @manageiq_uid ||= Process::UID.from_name("manageiq")
-    end
-
-    def manageiq_gid
-      @manageiq_gid ||= Process::GID.from_name("manageiq")
     end
   end
 end

--- a/lib/manageiq/appliance_console/key_configuration.rb
+++ b/lib/manageiq/appliance_console/key_configuration.rb
@@ -93,9 +93,9 @@ module ApplianceConsole
     end
 
     def create_key
-      result = !!ManageIQ::Password.generate_symmetric(NEW_KEY_FILE)
-      File.chown(manageiq_uid, manageiq_gid, NEW_KEY_FILE) if result
-      result
+      return unless !!ManageIQ::Password.generate_symmetric(NEW_KEY_FILE)
+
+      File.chown(manageiq_uid, manageiq_gid, NEW_KEY_FILE)
     end
 
     def fetch_key

--- a/lib/manageiq/appliance_console/manageiq_user_mixin.rb
+++ b/lib/manageiq/appliance_console/manageiq_user_mixin.rb
@@ -1,0 +1,15 @@
+module ManageIQ
+  module ApplianceConsole
+    module ManageiqUserMixin
+      extend ActiveSupport::Concern
+
+      def manageiq_uid
+        @manageiq_uid ||= Process::UID.from_name("manageiq")
+      end
+
+      def manageiq_gid
+        @manageiq_gid ||= Process::GID.from_name("manageiq")
+      end
+    end
+  end
+end

--- a/lib/manageiq/appliance_console/message_configuration.rb
+++ b/lib/manageiq/appliance_console/message_configuration.rb
@@ -120,10 +120,8 @@ module ManageIQ
           messaging_yaml["production"]["security.protocol"] = "PLAINTEXT"
         end
 
-        File.open(messaging_yaml_path, "w") do |f|
-          f.write(messaging_yaml.to_yaml)
-          f.chown(manageiq_uid, manageiq_gid)
-        end
+        File.write(messaging_yaml_path, messaging_yaml.to_yaml)
+        File.chown(manageiq_uid, manageiq_gid, messaging_yaml_path)
       end
 
       def remove_installed_files

--- a/lib/manageiq/appliance_console/message_configuration.rb
+++ b/lib/manageiq/appliance_console/message_configuration.rb
@@ -120,8 +120,10 @@ module ManageIQ
           messaging_yaml["production"]["security.protocol"] = "PLAINTEXT"
         end
 
-        File.write(messaging_yaml_path, messaging_yaml.to_yaml)
-        File.chown(manageiq_uid, manageiq_gid, messaging_yaml_path)
+        File.open(messaging_yaml_path, "w") do |f|
+          f.write(messaging_yaml.to_yaml)
+          f.chown(manageiq_uid, manageiq_gid)
+        end
       end
 
       def remove_installed_files

--- a/lib/manageiq/appliance_console/message_configuration.rb
+++ b/lib/manageiq/appliance_console/message_configuration.rb
@@ -1,9 +1,13 @@
 require 'active_support/core_ext/module/delegation'
 require 'pathname'
 
+require_relative './manageiq_user_mixin'
+
 module ManageIQ
   module ApplianceConsole
     class MessageConfiguration
+      include ManageIQ::ApplianceConsole::ManageiqUserMixin
+
       attr_reader :message_keystore_username, :message_keystore_password,
                   :message_server_host, :message_server_port,
                   :miq_config_dir_path, :config_dir_path, :sample_config_dir_path,
@@ -195,14 +199,6 @@ module ManageIQ
 
       def secure?
         message_server_port == 9_093
-      end
-
-      def manageiq_uid
-        @manageiq_uid ||= Process::UID.from_name("manageiq")
-      end
-
-      def manageiq_gid
-        @manageiq_gid ||= Process::GID.from_name("manageiq")
       end
     end
   end

--- a/lib/manageiq/appliance_console/message_configuration.rb
+++ b/lib/manageiq/appliance_console/message_configuration.rb
@@ -116,7 +116,10 @@ module ManageIQ
           messaging_yaml["production"]["security.protocol"] = "PLAINTEXT"
         end
 
-        File.write(messaging_yaml_path, messaging_yaml.to_yaml)
+        File.open(messaging_yaml_path, "w") do |f|
+          f.write(messaging_yaml.to_yaml)
+          f.chown(manageiq_uid, manageiq_gid)
+        end
       end
 
       def remove_installed_files
@@ -192,6 +195,14 @@ module ManageIQ
 
       def secure?
         message_server_port == 9_093
+      end
+
+      def manageiq_uid
+        @manageiq_uid ||= Process::UID.from_name("manageiq")
+      end
+
+      def manageiq_gid
+        @manageiq_gid ||= Process::GID.from_name("manageiq")
       end
     end
   end

--- a/spec/key_configuration_spec.rb
+++ b/spec/key_configuration_spec.rb
@@ -1,4 +1,9 @@
 describe ManageIQ::ApplianceConsole::KeyConfiguration do
+  before do
+    allow(Process::UID).to receive(:from_name).with("manageiq").and_return(Process.uid)
+    allow(Process::GID).to receive(:from_name).with("manageiq").and_return(Process.gid)
+  end
+
   context "#ask_questions" do
     subject { Class.new(described_class).tap { |c| c.include(ManageIQ::ApplianceConsole::Prompts) }.new }
 
@@ -63,6 +68,7 @@ describe ManageIQ::ApplianceConsole::KeyConfiguration do
           expect(Net::SCP).to receive(:start).with(host, "root", :password => password)
           expect(FileUtils).to receive(:mv).with(/v2_key\.tmp/, /v2_key$/, :force=>true).and_return(true)
           expect(FileUtils).to receive(:chmod).with(0o400, /v2_key/).and_return(["v2_key"])
+          expect(File).to receive(:chown).with(Process.uid, Process.gid, /v2_key\.tmp/)
           expect(subject.activate).to be_truthy
         end
 
@@ -72,6 +78,7 @@ describe ManageIQ::ApplianceConsole::KeyConfiguration do
           expect(ManageIQ::Password).to receive(:generate_symmetric).and_return(154)
           expect(FileUtils).to receive(:mv).with(/v2_key\.tmp/, /v2_key$/, :force=>true).and_return(true)
           expect(FileUtils).to receive(:chmod).with(0o400, /v2_key/).and_return(["v2_key"])
+          expect(File).to receive(:chown).with(Process.uid, Process.gid, /v2_key\.tmp/)
           expect(subject.activate).to be_truthy
         end
       end
@@ -86,6 +93,7 @@ describe ManageIQ::ApplianceConsole::KeyConfiguration do
           expect(Net::SCP).to receive(:start).with(host, "root", :password => password).and_yield(scp).and_return(true)
           expect(FileUtils).to receive(:mv).with(/v2_key\.tmp/, /v2_key$/, :force=>true).and_return(true)
           expect(FileUtils).to receive(:chmod).with(0o400, /v2_key/).and_return(["v2_key"])
+          expect(File).to receive(:chown).with(Process.uid, Process.gid, /v2_key\.tmp/)
           expect(subject.activate).to be_truthy
         end
 

--- a/spec/key_configuration_spec.rb
+++ b/spec/key_configuration_spec.rb
@@ -78,7 +78,7 @@ describe ManageIQ::ApplianceConsole::KeyConfiguration do
           expect(ManageIQ::Password).to receive(:generate_symmetric).and_return(154)
           expect(FileUtils).to receive(:mv).with(/v2_key\.tmp/, /v2_key$/, :force=>true).and_return(true)
           expect(FileUtils).to receive(:chmod).with(0o400, /v2_key/).and_return(["v2_key"])
-          expect(File).to receive(:chown).with(Process.uid, Process.gid, /v2_key\.tmp/)
+          expect(File).to receive(:chown).with(Process.uid, Process.gid, /v2_key\.tmp/).and_return(0)
           expect(subject.activate).to be_truthy
         end
       end

--- a/spec/message_configuration_client_spec.rb
+++ b/spec/message_configuration_client_spec.rb
@@ -27,6 +27,9 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
 
     FileUtils.mkdir_p("#{@tmp_base_dir}/config")
     FileUtils.mkdir_p("#{@tmp_base_dir}/config-sample")
+
+    allow(Process::UID).to receive(:from_name).with("manageiq").and_return(Process.uid)
+    allow(Process::GID).to receive(:from_name).with("manageiq").and_return(Process.gid)
   end
 
   after do

--- a/spec/message_configuration_client_spec.rb
+++ b/spec/message_configuration_client_spec.rb
@@ -271,7 +271,7 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
 
     shared_examples "messaging yaml file" do
       it "creates the messaging yaml file" do
-        expect(subject.send(:configure_messaging_yaml)).to be_positive
+        subject.send(:configure_messaging_yaml)
         expect(subject.messaging_yaml_path).to exist
       end
 
@@ -284,6 +284,7 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
 
       it "correctly populates the messaging yaml file" do
         expect(File).to receive(:write).with(subject.messaging_yaml_path, content)
+        expect(File).to receive(:chown).with(Process.uid, Process.gid, subject.messaging_yaml_path)
         expect(subject.send(:configure_messaging_yaml)).to be_nil
       end
     end

--- a/spec/message_configuration_client_spec.rb
+++ b/spec/message_configuration_client_spec.rb
@@ -283,8 +283,12 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
       end
 
       it "correctly populates the messaging yaml file" do
-        expect(File).to receive(:write).with(subject.messaging_yaml_path, content)
-        expect(File).to receive(:chown).with(Process.uid, Process.gid, subject.messaging_yaml_path)
+        allow(File).to receive(:open).and_call_original
+
+        file_stub = double("File")
+        expect(File).to receive(:open).with(subject.messaging_yaml_path, "w").and_yield(file_stub)
+        expect(file_stub).to receive(:write).with(content)
+        expect(file_stub).to receive(:chown).with(Process.uid, Process.gid)
         expect(subject.send(:configure_messaging_yaml)).to be_nil
       end
     end


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq/issues/21358

Files which get written as root and cause workers to fail to start up:
- [x] `config/database.yml`
- [x] `config/messaging.yml`
- [x] `certs/v2_key`
