### PR TITLE
Add missing parse_errors() method

### DIFF
--- a/lib/manageiq/appliance_console/external_auth_options.rb
+++ b/lib/manageiq/appliance_console/external_auth_options.rb
@@ -82,8 +82,7 @@ module ApplianceConsole
         say("\nUpdating external authentication options on appliance ...")
         params = update_hash.collect { |key, value| "#{key}=#{value}" }
         params = configure_provider_type!(params)
-        result = ManageIQ::ApplianceConsole::Utilities.rake_run("evm:settings:set", params)
-        raise parse_errors(result).join(', ') if result.failure?
+        ManageIQ::ApplianceConsole::Utilities.rake_run!("evm:settings:set", params)
       end
     end
 
@@ -152,17 +151,8 @@ module ApplianceConsole
 
     def load_current
       say("\nFetching external authentication options from appliance ...")
-      result = ManageIQ::ApplianceConsole::Utilities.rake_run("evm:settings:get", EXT_AUTH_OPTIONS.keys)
-
-      if result.success?
-        return parse_response(result)
-      else
-        raise parse_errors(result).join(', ')
-      end
-    end
-
-    def parse_errors(result)
-      result.error.split("\n").collect { |line| line if line =~ /^error: /i }.compact
+      result = ManageIQ::ApplianceConsole::Utilities.rake_run!("evm:settings:get", EXT_AUTH_OPTIONS.keys)
+      parse_response(result)
     end
 
     def normalize_key(key)

--- a/lib/manageiq/appliance_console/message_configuration.rb
+++ b/lib/manageiq/appliance_console/message_configuration.rb
@@ -194,6 +194,12 @@ module ManageIQ
       def secure?
         message_server_port == 9_093
       end
+
+      private
+
+      def parse_errors(result)
+        result.error.split("\n").collect { |line| line if line =~ /^error: /i }.compact
+      end
     end
   end
 end

--- a/lib/manageiq/appliance_console/message_configuration.rb
+++ b/lib/manageiq/appliance_console/message_configuration.rb
@@ -175,8 +175,7 @@ module ManageIQ
       def configure_messaging_type(value)
         say(__method__.to_s.tr("_", " ").titleize)
 
-        result = ManageIQ::ApplianceConsole::Utilities.rake_run("evm:settings:set", ["/prototype/messaging_type=#{value}"])
-        raise parse_errors(result).join(', ') if result.failure?
+        ManageIQ::ApplianceConsole::Utilities.rake_run!("evm:settings:set", ["/prototype/messaging_type=#{value}"])
       end
 
       def restart_evmserverd
@@ -193,12 +192,6 @@ module ManageIQ
 
       def secure?
         message_server_port == 9_093
-      end
-
-      private
-
-      def parse_errors(result)
-        result.error.split("\n").collect { |line| line if line =~ /^error: /i }.compact
       end
     end
   end

--- a/lib/manageiq/appliance_console/utilities.rb
+++ b/lib/manageiq/appliance_console/utilities.rb
@@ -16,6 +16,16 @@ module ApplianceConsole
       result
     end
 
+    def self.rake_run!(task, params)
+      result = rake_run(task, params)
+      if result.failure?
+        parsed_errors = result.error.split("\n").select { |line| line.match?(/^error: /i) }.join(', ')
+        raise parsed_errors
+      end
+
+      result
+    end
+
     def self.db_connections
       result = AwesomeSpawn.run("bin/rails runner",
                                 :params => ["exit EvmDatabaseOps.database_connections"],


### PR DESCRIPTION
When configuring the messaging_type fails the `MessageConfiguration` class raises `raise parse_errors(result)` but the parse_errors method didn't exist.

Fixes https://github.com/ManageIQ/manageiq-appliance_console/issues/166