### PR TITLE
Create /opt/kafka/config/keystore directory

### DIFF
--- a/lib/manageiq/appliance_console/message_configuration_client.rb
+++ b/lib/manageiq/appliance_console/message_configuration_client.rb
@@ -82,6 +82,8 @@ module ManageIQ
       def fetch_from_server(src_file, dst_file)
         return if file_found?(dst_file)
 
+        FileUtils.mkdir_p(dst_file.dirname) unless dst_file.dirname.directory?
+
         Net::SCP.start(message_server_host, message_server_username, :password => message_server_password) do |scp|
           scp.download!(src_file, dst_file)
         end

--- a/lib/manageiq/appliance_console/message_configuration_server.rb
+++ b/lib/manageiq/appliance_console/message_configuration_server.rb
@@ -184,6 +184,8 @@ module ManageIQ
 
         keystore_params = assemble_keystore_params
 
+        FileUtils.mkdir_p(keystore_dir_path) unless keystore_dir_path.directory?
+
         # Generte a Java keystore and key pair, creating keystore.jks
         # :stdin_data provides the -storepass twice to confirm and an extra CR to accept the same password for -keypass
         AwesomeSpawn.run!("keytool", :params => keystore_params, :stdin_data => "#{message_keystore_password}\n#{message_keystore_password}\n\n")


### PR DESCRIPTION
Create the keystore directory before writing config files to it.

Fixes https://github.com/ManageIQ/manageiq/issues/21357