### PR TITLE
Pull in .db_connections code from core

### DIFF
--- a/lib/manageiq/appliance_console/utilities.rb
+++ b/lib/manageiq/appliance_console/utilities.rb
@@ -27,8 +27,13 @@ module ApplianceConsole
     end
 
     def self.db_connections
+      code   = [
+        "database ||= ActiveRecord::Base.configurations[Rails.env]['database']",
+        "conn = ActiveRecord::Base.connection",
+        "exit conn.client_connections.count { |c| c['database'] == database }"
+      ]
       result = AwesomeSpawn.run("bin/rails runner",
-                                :params => ["exit EvmDatabaseOps.database_connections"],
+                                :params => [code.join("; ")],
                                 :chdir  => ManageIQ::ApplianceConsole::RAILS_ROOT
                                )
       Integer(result.exit_status)


### PR DESCRIPTION
Inline code that was originally part of `EvmDatabaseOps.database_connections` so that it is now owned by `ManageIQ::ApplianceConsole`.

Addresses concern in https://github.com/ManageIQ/manageiq/pull/21384#issuecomment-902969910