### PR TITLE
Check if kafka is configured before presenting options

### DIFF
--- a/bin/appliance_console
+++ b/bin/appliance_console
@@ -425,7 +425,11 @@ Static Network Configuration
           say("#{selection}\n\n")
 
           message_server = MessageServerConfiguration.new
-          if message_server.ask_questions && message_server.configure
+          if !MessageServerConfiguration.available?
+            say("\nMessage Server configuration is unavailable!\n")
+            press_any_key
+            raise MiqSignalError
+          elsif message_server.ask_questions && message_server.configure
             say("\nMessage Server configured successfully.\n")
             press_any_key
           else
@@ -438,7 +442,11 @@ Static Network Configuration
           say("#{selection}\n\n")
 
           message_client = MessageClientConfiguration.new
-          if message_client.ask_questions && message_client.configure
+          if !MessageClientConfiguration.available?
+            say("\nMessage Client configuration is unavailable!\n")
+            press_any_key
+            raise MiqSignalError
+          elsif message_client.ask_questions && message_client.configure
             say("\nMessage Client configured successfully.\n")
             press_any_key
           else

--- a/lib/manageiq/appliance_console/cli.rb
+++ b/lib/manageiq/appliance_console/cli.rb
@@ -509,6 +509,8 @@ module ApplianceConsole
     end
 
     def message_server_config
+      raise "Message Server Configuration is not available" unless MessageServerConfiguration.available?
+
       MessageServerConfiguration.new(options).configure
     end
 
@@ -517,6 +519,8 @@ module ApplianceConsole
     end
 
     def message_client_config
+      raise "Message Client Configuration is not available" unless MessageClientConfiguration.available?
+
       MessageClientConfiguration.new(options).configure
     end
 

--- a/lib/manageiq/appliance_console/message_configuration.rb
+++ b/lib/manageiq/appliance_console/message_configuration.rb
@@ -22,6 +22,10 @@ module ManageIQ
       SAMPLE_CONFIG_DIR                 = "#{BASE_DIR}/config-sample".freeze
       MIQ_CONFIG_DIR                    = ManageIQ::ApplianceConsole::RAILS_ROOT.join("config").freeze
 
+      def self.available?
+        File.exist?("#{BASE_DIR}/bin/kafka-run-class.sh")
+      end
+
       def initialize(options = {})
         @message_server_port        = options[:message_server_port] || 9093
         @message_keystore_username  = options[:message_keystore_username] || "admin"


### PR DESCRIPTION
Before presenting the --message-server-config and --message-client-config options check if a messaging system is available.  For now this consists of checking if Kafka is present.

TODO:
- [x] appliance_console_cli
- [x] appliance_console menu

Appliance Console Menu:
```
Configure Application


Message Server configuration is unavailable!

Press any key to continue.
```

Appliance Console CLI:
```
[root@manageiq ~]# appliance_console_cli --message-server-config
Traceback (most recent call last):
	5: from /opt/manageiq/manageiq-gemset/bin/appliance_console_cli:23:in `<main>'
	4: from /opt/manageiq/manageiq-gemset/bin/appliance_console_cli:23:in `load'
	3: from /opt/manageiq/manageiq-gemset/gems/manageiq-appliance_console-7.0.2/bin/appliance_console_cli:7:in `<top (required)>'
	2: from /opt/manageiq/manageiq-gemset/gems/manageiq-appliance_console-7.0.2/lib/manageiq/appliance_console/cli.rb:547:in `parse'
	1: from /opt/manageiq/manageiq-gemset/gems/manageiq-appliance_console-7.0.2/lib/manageiq/appliance_console/cli.rb:279:in `run'
/opt/manageiq/manageiq-gemset/gems/manageiq-appliance_console-7.0.2/lib/manageiq/appliance_console/cli.rb:512:in `message_server_config': Message Server Configuration is not available (RuntimeError)
```