### PR TITLE
pass region as an environmental variable for db creation

### DIFF
--- a/lib/manageiq/appliance_console/database_configuration.rb
+++ b/lib/manageiq/appliance_console/database_configuration.rb
@@ -89,7 +89,7 @@ module ApplianceConsole
       hint = "Please stop the EVM server process on all appliances in the region"
       ManageIQ::ApplianceConsole::Utilities.bail_if_db_connections("preventing the setup of a database region.\n#{hint}")
       log_and_feedback(__method__) do
-        ManageIQ::ApplianceConsole::Utilities.rake("evm:db:region", ["--", {:region => region}])
+        ManageIQ::ApplianceConsole::Utilities.rake("evm:db:region", {}, {'REGION' => region, 'VERBOSE' => 'false'})
       end
     end
 

--- a/lib/manageiq/appliance_console/utilities.rb
+++ b/lib/manageiq/appliance_console/utilities.rb
@@ -10,8 +10,8 @@ module ApplianceConsole
       rake_run(task, params).success?
     end
 
-    def self.rake_run(task, params)
-      result = AwesomeSpawn.run("rake #{task}", :chdir => ManageIQ::ApplianceConsole::RAILS_ROOT, :params => params)
+    def self.rake_run(task, params, env = {})
+      result = AwesomeSpawn.run("rake #{task}", :chdir => ManageIQ::ApplianceConsole::RAILS_ROOT, :params => params, :env => env)
       ManageIQ::ApplianceConsole.logger.error(result.error) if result.failure?
       result
     end


### PR DESCRIPTION
FYI:

- This started https://github.com/ManageIQ/manageiq/pull/6248
- continued through https://github.com/ManageIQ/manageiq/pull/17257
- Where it ends https://github.com/ManageIQ/manageiq/pull/21981

### What

Transitioning to using an environment variable.

### Why

If we use a `REGION` env variable then we can transition from `rake evm:db:region` to  `rake db:migrate` or `rake db:reset`
