### PR TITLE
pass region as a string

### DIFF
--- a/lib/manageiq/appliance_console/database_configuration.rb
+++ b/lib/manageiq/appliance_console/database_configuration.rb
@@ -89,7 +89,7 @@ module ApplianceConsole
       hint = "Please stop the EVM server process on all appliances in the region"
       ManageIQ::ApplianceConsole::Utilities.bail_if_db_connections("preventing the setup of a database region.\n#{hint}")
       log_and_feedback(__method__) do
-        ManageIQ::ApplianceConsole::Utilities.rake("evm:db:region", {}, {'REGION' => region, 'VERBOSE' => 'false'})
+        ManageIQ::ApplianceConsole::Utilities.rake("evm:db:region", {}, {'REGION' => region.to_s, 'VERBOSE' => 'false'})
       end
     end
 

--- a/spec/database_configuration_spec.rb
+++ b/spec/database_configuration_spec.rb
@@ -114,13 +114,13 @@ describe ManageIQ::ApplianceConsole::DatabaseConfiguration do
 
     it "normal case" do
       expect(@config).not_to receive(:log_and_feedback_exception)
-      stub_good_run("rake evm:db:region", :chdir => ManageIQ::ApplianceConsole::RAILS_ROOT, :env=>{"REGION" => 42, "VERBOSE" => "false"}, :params => {})
+      stub_good_run("rake evm:db:region", :chdir => ManageIQ::ApplianceConsole::RAILS_ROOT, :env => {"REGION" => "42", "VERBOSE" => "false"}, :params => {})
       expect(@config.create_region).to be_truthy
     end
 
     it "failure" do
       expect(@config).not_to receive(:log_and_feedback_exception)
-      stub_bad_run("rake evm:db:region", :chdir => ManageIQ::ApplianceConsole::RAILS_ROOT, :env=>{"REGION" => 42, "VERBOSE" => "false"}, :params => {})
+      stub_bad_run("rake evm:db:region", :chdir => ManageIQ::ApplianceConsole::RAILS_ROOT, :env => {"REGION" => "42", "VERBOSE" => "false"}, :params => {})
       expect(@config.create_region).to be_falsey
     end
   end


### PR DESCRIPTION
take 3 on https://github.com/ManageIQ/manageiq-appliance_console/pull/182

```
[root@localhost vmdb]# cat log/appliance_console.log 
# Logfile created on 2022-07-14 11:40:47 -0400 by logger.rb/v1.4.2
I, [2022-07-14T11:40:47.532979 #1454]  INFO -- : MIQ(ManageIQ::ApplianceConsole::InternalDatabaseConfiguration#initialize_postgresql) : starting
I, [2022-07-14T11:40:51.124285 #1454]  INFO -- : MIQ(ManageIQ::ApplianceConsole::InternalDatabaseConfiguration#initialize_postgresql) : complete
I, [2022-07-14T11:41:02.117361 #1454]  INFO -- : MIQ(ManageIQ::ApplianceConsole::InternalDatabaseConfiguration#create_region) : starting
E, [2022-07-14T11:41:02.117663 #1454] ERROR -- : MIQ(ManageIQ::ApplianceConsole::InternalDatabaseConfiguration#create_region)  Error: TypeError with message: no implicit conversion of Integer into String. Failed at: /usr/share/ruby/open3.rb:213:in `spawn'
```