### PR TITLE
6.1 configurations has symbol keys, [] deprecated, use configs_for

### DIFF
--- a/lib/manageiq/appliance_console/utilities.rb
+++ b/lib/manageiq/appliance_console/utilities.rb
@@ -27,8 +27,13 @@ module ApplianceConsole
     end
 
     def self.db_connections
+      # TODO: this is impossible to test right now because we need to shell out and run our rails app which isn't a direct dependency here.
+      # We have the settings from the database_configuration, so we should pass them here and simplify this and make it testable.
+      # Basically, we're doing a lot of work to run this 1 query:
+      #   psql -U username -h host postgres -c "select count(*) from pg_stat_activity where datname = 'vmdb_production';"
+      # We shouldn't need to subtract our 1 "connection" in "bail_if_db_connections" if we connect to the postgres db.
       code   = [
-        "database ||= ActiveRecord::Base.configurations[Rails.env]['database']",
+        "database ||= ActiveRecord::Base.configurations.configs_for(:env_name => Rails.env).first.database",
         "conn = ActiveRecord::Base.connection",
         "exit conn.client_connections.count { |c| c['database'] == database }"
       ]


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-appliance/issues/366

DEPRECATION WARNING: [] is deprecated and will be removed from Rails 6.2 (Use configs_for)

This fixes the deprecation
This now uses symbols for configuration keys (since rails 6.1 has changed this as well)

Similar to: https://github.com/ManageIQ/manageiq/pull/21652/commits/0d57f5efbba53b5b27656f81922031320691750a