### PR TITLE
Report messaging configuration for application configuration

### DIFF
--- a/bin/appliance_console
+++ b/bin/appliance_console
@@ -92,18 +92,20 @@ module ApplianceConsole
       eth0.reload
       eth0.parse_conf if eth0.respond_to?(:parse_conf)
 
-      host        = LinuxAdmin::Hosts.new.hostname
-      ip          = eth0.address
-      mac         = eth0.mac_address
-      mask        = eth0.netmask
-      gw          = eth0.gateway
-      dns1, dns2  = dns.nameservers
-      order       = dns.search_order.join(' ')
-      timezone    = LinuxAdmin::TimeDate.system_timezone
-      version     = File.read(VERSION_FILE).chomp if File.exist?(VERSION_FILE)
-      dbhost      = ManageIQ::ApplianceConsole::DatabaseConfiguration.database_host
-      database    = ManageIQ::ApplianceConsole::DatabaseConfiguration.database_name
-      evm_running = LinuxAdmin::Service.new("evmserverd").running?
+      host             = LinuxAdmin::Hosts.new.hostname
+      ip               = eth0.address
+      mac              = eth0.mac_address
+      mask             = eth0.netmask
+      gw               = eth0.gateway
+      dns1, dns2       = dns.nameservers
+      order            = dns.search_order.join(' ')
+      timezone         = LinuxAdmin::TimeDate.system_timezone
+      version          = File.read(VERSION_FILE).chomp if File.exist?(VERSION_FILE)
+      dbhost           = ManageIQ::ApplianceConsole::DatabaseConfiguration.database_host
+      database         = ManageIQ::ApplianceConsole::DatabaseConfiguration.database_name
+      evm_running      = LinuxAdmin::Service.new("evmserverd").running?
+      messaging        = ManageIQ::ApplianceConsole::MessageConfiguration.configured?
+      messaging_broker = ManageIQ::ApplianceConsole::MessageServerConfiguration.configured?
 
       summary_attributes = [
         summary_entry("Hostname", host),
@@ -120,6 +122,8 @@ module ApplianceConsole
         summary_entry("#{I18n.t("product.name")} Server", evm_running ? "running" : "not running"),
         summary_entry("#{I18n.t("product.name")} Database", dbhost || "not configured"),
         summary_entry("Database/Region", database ? "#{database} / #{region.to_i}" : "not configured"),
+        summary_entry("Messaging", messaging ? "configured" : "not configured"),
+        summary_entry("Local Messaging Broker", messaging_broker ? "configured" : "not configured"),
         summary_entry("External Auth", ExternalHttpdAuthentication.config_status),
         summary_entry("#{I18n.t("product.name")} Version", version),
       ]
@@ -437,7 +441,6 @@ Static Network Configuration
             press_any_key
             raise MiqSignalError
           end
-
         when "message_client"
           say("#{selection}\n\n")
 

--- a/lib/manageiq/appliance_console/message_configuration.rb
+++ b/lib/manageiq/appliance_console/message_configuration.rb
@@ -26,6 +26,10 @@ module ManageIQ
         File.exist?("#{BASE_DIR}/bin/kafka-run-class.sh")
       end
 
+      def self.configured?
+        MessageServerConfiguration.configured? || MessageClientConfiguration.configured?
+      end
+
       def initialize(options = {})
         @message_server_port        = options[:message_server_port] || 9093
         @message_keystore_username  = options[:message_keystore_username] || "admin"

--- a/lib/manageiq/appliance_console/message_configuration_client.rb
+++ b/lib/manageiq/appliance_console/message_configuration_client.rb
@@ -77,6 +77,10 @@ module ManageIQ
         fetch_from_server(message_ca_cert_path_src, ca_cert_path)
       end
 
+      def self.configured?
+        MessageClientConfiguration.new.installed_files.all? { |f| File.exist?(f) }
+      end
+
       private
 
       def fetch_from_server(src_file, dst_file)


### PR DESCRIPTION
- require users to configure messaging if they do not already have it configured when setting up the application

@miq-bot add_label enhancement
@miq-bot assign @agrare 