### PR TITLE
Make backward compatible changes to work with repmgr13 - version 5.2.1

### DIFF
--- a/lib/manageiq/appliance_console/database_replication.rb
+++ b/lib/manageiq/appliance_console/database_replication.rb
@@ -54,16 +54,18 @@ Replication Server Configuration
 
     def config_file_contents(host)
       service_name = PostgresAdmin.service_name
+      # FYI, 5.0 made quoting strings strict.  Always use single quoted strings.
+      # https://repmgr.org/docs/current/release-5.0.html
       <<-EOS.strip_heredoc
-        node_id=#{node_number}
-        node_name=#{host}
+        node_id='#{node_number}'
+        node_name='#{host}'
         conninfo='host=#{host} user=#{database_user} dbname=#{database_name}'
-        use_replication_slots=1
+        use_replication_slots='1'
         pg_basebackup_options='--wal-method=stream'
-        failover=automatic
+        failover='automatic'
         promote_command='repmgr standby promote -f #{REPMGR_CONFIG} --log-to-file'
         follow_command='repmgr standby follow -f #{REPMGR_CONFIG} --log-to-file --upstream-node-id=%n'
-        log_file=#{REPMGR_LOG}
+        log_file='#{REPMGR_LOG}'
         service_start_command='sudo systemctl start #{service_name}'
         service_stop_command='sudo systemctl stop #{service_name}'
         service_restart_command='sudo systemctl restart #{service_name}'

--- a/lib/manageiq/appliance_console/database_replication.rb
+++ b/lib/manageiq/appliance_console/database_replication.rb
@@ -7,8 +7,8 @@ module ApplianceConsole
   class DatabaseReplication
     include ManageIQ::ApplianceConsole::Logging
 
-    REPMGR_CONFIG     = '/etc/repmgr/10/repmgr.conf'.freeze
-    REPMGR_LOG        = '/var/log/repmgr/repmgrd.log'.freeze
+    REPMGR_CONFIG     = '/etc/repmgr/13/repmgr.conf'.freeze
+    REPMGR_LOG        = '/var/log/repmgr/repmgrd-13.log'.freeze
     PGPASS_FILE       = '/var/lib/pgsql/.pgpass'.freeze
     NETWORK_INTERFACE = 'eth0'.freeze
 

--- a/lib/manageiq/appliance_console/database_replication_standby.rb
+++ b/lib/manageiq/appliance_console/database_replication_standby.rb
@@ -8,7 +8,6 @@ module ApplianceConsole
     include ManageIQ::ApplianceConsole::Logging
 
     REGISTER_CMD    = 'repmgr standby register'.freeze
-    REPMGRD_SERVICE = 'repmgr13'.freeze
 
     attr_accessor :disk, :standby_host, :run_repmgrd_configuration, :resync_data, :force_register
 
@@ -111,7 +110,7 @@ module ApplianceConsole
     end
 
     def start_repmgrd
-      LinuxAdmin::Service.new(REPMGRD_SERVICE).enable.start
+      LinuxAdmin::Service.new(repmgr_service_name).enable.start
       true
     rescue AwesomeSpawn::CommandResultError => e
       message = "Failed to start repmgrd: #{e.message}"
@@ -121,7 +120,7 @@ module ApplianceConsole
     end
 
     def stop_repmgrd
-      LinuxAdmin::Service.new(REPMGRD_SERVICE).stop
+      LinuxAdmin::Service.new(repmgr_service_name).stop
       true
     end
 

--- a/lib/manageiq/appliance_console/database_replication_standby.rb
+++ b/lib/manageiq/appliance_console/database_replication_standby.rb
@@ -8,7 +8,7 @@ module ApplianceConsole
     include ManageIQ::ApplianceConsole::Logging
 
     REGISTER_CMD    = 'repmgr standby register'.freeze
-    REPMGRD_SERVICE = 'repmgr10'.freeze
+    REPMGRD_SERVICE = 'repmgr13'.freeze
 
     attr_accessor :disk, :standby_host, :run_repmgrd_configuration, :resync_data, :force_register
 

--- a/spec/database_replication_spec.rb
+++ b/spec/database_replication_spec.rb
@@ -51,7 +51,7 @@ describe ManageIQ::ApplianceConsole::DatabaseReplication do
   context "#create_config_file" do
     it "writes the config file contents" do
       expect(subject).to receive(:config_file_contents).and_return("the contents")
-      expect(File).to receive(:write).with(described_class::REPMGR_CONFIG, "the contents")
+      expect(File).to receive(:write).with(described_class.repmgr_config, "the contents")
       expect(subject.create_config_file("host")).to be true
     end
   end
@@ -59,15 +59,15 @@ describe ManageIQ::ApplianceConsole::DatabaseReplication do
   context "#config_file_contents" do
     let(:expected_config_file) do
       <<-EOS.strip_heredoc
-        node_id=nodenumber
-        node_name=host
+        node_id='nodenumber'
+        node_name='host'
         conninfo='host=host user=user dbname=databasename'
-        use_replication_slots=1
+        use_replication_slots='1'
         pg_basebackup_options='--wal-method=stream'
-        failover=automatic
+        failover='automatic'
         promote_command='repmgr standby promote -f /etc/repmgr/10/repmgr.conf --log-to-file'
         follow_command='repmgr standby follow -f /etc/repmgr/10/repmgr.conf --log-to-file --upstream-node-id=%n'
-        log_file=/var/log/repmgr/repmgrd.log
+        log_file='/var/log/repmgr/repmgrd.log'
         service_start_command='sudo systemctl start postgresql-9.5'
         service_stop_command='sudo systemctl stop postgresql-9.5'
         service_restart_command='sudo systemctl restart postgresql-9.5'

--- a/spec/postgres_admin_spec.rb
+++ b/spec/postgres_admin_spec.rb
@@ -334,14 +334,14 @@ describe ManageIQ::ApplianceConsole::PostgresAdmin do
         end
       end
 
-      describe ".local_server_in_recovery?" do
-        it "returns true when recovery.conf exists" do
-          FileUtils.touch("#{ENV["APPLIANCE_PG_DATA"]}/recovery.conf")
-          expect(described_class.local_server_in_recovery?).to be true
+      describe ".local_server_received_standby_signal?" do
+        it "returns true when standby.signal exists" do
+          FileUtils.touch("#{ENV["APPLIANCE_PG_DATA"]}/standby.signal")
+          expect(described_class.local_server_received_standby_signal?).to be true
         end
 
-        it "returns false when recovery.conf does not exist" do
-          expect(described_class.local_server_in_recovery?).to be false
+        it "returns false when standby.signal does not exist" do
+          expect(described_class.local_server_received_standby_signal?).to be false
         end
       end
 
@@ -358,12 +358,12 @@ describe ManageIQ::ApplianceConsole::PostgresAdmin do
             allow(service).to receive(:running?).and_return(true)
           end
 
-          it "returns a running status and primary with no recovery file" do
+          it "returns a running status and primary with no standby.signal file" do
             expect(described_class.local_server_status).to eq("running (primary)")
           end
 
-          it "returns a running status and standby with a recovery file" do
-            FileUtils.touch("#{ENV["APPLIANCE_PG_DATA"]}/recovery.conf")
+          it "returns a running status and standby with a standby.signal file" do
+            FileUtils.touch("#{ENV["APPLIANCE_PG_DATA"]}/standby.signal")
             expect(described_class.local_server_status).to eq("running (standby)")
           end
         end


### PR DESCRIPTION
We're upgrading from 4.0.6 to 5.2.1 along with PG 10 to PG 13.

See: ManageIQ/manageiq-rpm_build#309

* configuration: single quote strings... don't leave them unquoted to be safe
* recovery.conf is gone in PG 12+ / use standby.signal instead to detect a standby (or lack of it for a primary)
* Keep compatibility with repmgr10 for now 