### PR TITLE
Don't require user to press_any_key twice after successful messaging configuration

### DIFF
--- a/bin/appliance_console
+++ b/bin/appliance_console
@@ -435,7 +435,6 @@ Static Network Configuration
             raise MiqSignalError
           elsif message_server.ask_questions && message_server.configure
             say("\nMessage Server configured successfully.\n")
-            press_any_key
           else
             say("\nMessage Server configuration failed!\n")
             press_any_key
@@ -451,7 +450,6 @@ Static Network Configuration
             raise MiqSignalError
           elsif message_client.ask_questions && message_client.configure
             say("\nMessage Client configured successfully.\n")
-            press_any_key
           else
             say("\nMessage Client configuration failed!\n")
             press_any_key


### PR DESCRIPTION
When configuring messaging succeeds we have the user have to hit any key twice to return to the main appliance_console overview:

```
Configure Messaging Type
Starting zookeeper and configure it to start on reboots ...
Starting kafka and configure it to start on reboots ...
Restart evmserverd if it is running...

Message Server configured successfully.

Press any key to continue.

Press any key to continue.
```