### PR TITLE
Don't start evmserverd if messaging is not configured

### DIFF
--- a/bin/appliance_console
+++ b/bin/appliance_console
@@ -103,9 +103,15 @@ module ApplianceConsole
       version          = File.read(VERSION_FILE).chomp if File.exist?(VERSION_FILE)
       dbhost           = ManageIQ::ApplianceConsole::DatabaseConfiguration.database_host
       database         = ManageIQ::ApplianceConsole::DatabaseConfiguration.database_name
-      evm_running      = ManageIQ::ApplianceConsole::EvmServer.running?
       messaging        = ManageIQ::ApplianceConsole::MessageConfiguration.configured?
       messaging_broker = ManageIQ::ApplianceConsole::MessageServerConfiguration.configured?
+      evm_status       = if ManageIQ::ApplianceConsole::EvmServer.running?
+        "running"
+      elsif ManageIQ::ApplianceConsole::EvmServer.runnable?
+        "not running"
+      else
+        "not configured"
+      end
 
       summary_attributes = [
         summary_entry("Hostname", host),
@@ -119,7 +125,7 @@ module ApplianceConsole
         summary_entry("MAC Address", mac),
         summary_entry("Timezone", timezone),
         summary_entry("Local Database Server", PostgresAdmin.local_server_status),
-        summary_entry("#{I18n.t("product.name")} Server", evm_running ? "running" : "not running"),
+        summary_entry("#{I18n.t("product.name")} Server", evm_status),
         summary_entry("#{I18n.t("product.name")} Database", dbhost || "not configured"),
         summary_entry("Database/Region", database ? "#{database} / #{region.to_i}" : "not configured"),
         summary_entry("Messaging", messaging ? "configured" : "not configured"),

--- a/lib/manageiq/appliance_console/database_configuration.rb
+++ b/lib/manageiq/appliance_console/database_configuration.rb
@@ -12,7 +12,7 @@ module ApplianceConsole
   class DatabaseConfiguration
     include ManageIQ::ApplianceConsole::ManageiqUserMixin
 
-    attr_accessor :adapter, :host, :username, :database, :port, :region
+    attr_accessor :adapter, :host, :username, :database, :port, :region, :run_as_evm_server
     attr_reader :password
 
     class ModelWithNoBackingTable < ActiveRecord::Base
@@ -38,6 +38,7 @@ module ApplianceConsole
       @adapter ||= "postgresql"
       # introduced by Logging
       self.interactive = true unless hash.key?(:interactive)
+      self.run_as_evm_server = true unless hash.key?(:run_as_evm_server)
     end
 
     def run_interactive

--- a/lib/manageiq/appliance_console/evm_server.rb
+++ b/lib/manageiq/appliance_console/evm_server.rb
@@ -1,21 +1,30 @@
 module ManageIQ
   module ApplianceConsole
     class EvmServer
+      class NotRunnableError < RuntimeError; end
+
       class << self
         def running?
           service.running?
         end
 
         def start!(enable: false)
+          raise NotRunnableError, "Cannot start #{I18n.t("product.name")}: #{not_runnable_reason}" unless runnable?
+
           service.start(enable)
         end
 
         def start(enable: false)
           start!(:enable => enable)
         rescue AwesomeSpawn::CommandResultError => e
-          say e.result.output
-          say e.result.error
-          say ""
+          say(e.result.output)
+          say(e.result.error)
+          say("")
+          false
+        rescue NotRunnableError => e
+          say(e.to_s)
+          say("")
+          false
         end
 
         def stop
@@ -32,6 +41,18 @@ module ManageIQ
 
         def disable
           service.disable
+        end
+
+        def runnable?
+          DatabaseConfiguration.database_yml_configured? && MessageConfiguration.configured?
+        end
+
+        def not_runnable_reason
+          if !DatabaseConfiguration.database_yml_configured?
+            "A Database connection has not been configured."
+          elsif !MessageConfiguration.configured?
+            "Messaging has not been configured."
+          end
         end
 
         private

--- a/lib/manageiq/appliance_console/internal_database_configuration.rb
+++ b/lib/manageiq/appliance_console/internal_database_configuration.rb
@@ -5,7 +5,7 @@ require "linux_admin"
 module ManageIQ
 module ApplianceConsole
   class InternalDatabaseConfiguration < DatabaseConfiguration
-    attr_accessor :disk, :run_as_evm_server
+    attr_accessor :disk
 
     DEDICATED_DB_SHARED_BUFFERS = "'1GB'".freeze
     SHARED_DB_SHARED_BUFFERS = "'128MB'".freeze
@@ -24,10 +24,9 @@ module ApplianceConsole
     end
 
     def set_defaults
-      self.host              = 'localhost'
-      self.username          = "root"
-      self.database          = "vmdb_production"
-      self.run_as_evm_server = true
+      self.host     = 'localhost'
+      self.username = "root"
+      self.database = "vmdb_production"
     end
 
     def activate

--- a/lib/manageiq/appliance_console/message_configuration.rb
+++ b/lib/manageiq/appliance_console/message_configuration.rb
@@ -187,14 +187,7 @@ module ManageIQ
         true
       end
 
-      def configure_messaging_type(value)
-        say(__method__.to_s.tr("_", " ").titleize)
-
-        ManageIQ::ApplianceConsole::Utilities.rake_run!("evm:settings:set", ["/prototype/messaging_type=#{value}"])
-      end
-
       def unconfigure
-        configure_messaging_type("miq_queue") # Settings.prototype.messaging_type = 'miq_queue'
         remove_installed_files
       end
 

--- a/lib/manageiq/appliance_console/message_configuration_client.rb
+++ b/lib/manageiq/appliance_console/message_configuration_client.rb
@@ -29,7 +29,6 @@ module ManageIQ
           configure_messaging_yaml          # Set up the local message client in case EVM is actually running on this, Message Server
           create_client_properties          # Create the client.properties configuration fle
           fetch_truststore_from_server      # Fetch the Java Keystore from the Kafka Server
-          configure_messaging_type("kafka") # Settings.prototype.messaging_type = 'kafka'
         rescue AwesomeSpawn::CommandResultError => e
           say(e.result.output)
           say(e.result.error)

--- a/lib/manageiq/appliance_console/message_configuration_server.rb
+++ b/lib/manageiq/appliance_console/message_configuration_server.rb
@@ -43,7 +43,6 @@ module ManageIQ
           configure_keystore                # Populate the Java Keystore
           create_server_properties          # Update the /opt/message/config/server.properties
           configure_messaging_yaml          # Set up the local message client in case EVM is actually running on this, Message Server
-          configure_messaging_type("kafka") # Settings.prototype.messaging_type = 'kafka'
           restart_services
         rescue AwesomeSpawn::CommandResultError => e
           say(e.result.output)


### PR DESCRIPTION
Only start evmserverd once database and messaging have been configured

NOTE added a third state to `ManageIQ Server`: `running, not running, not configured` so it is consistent with the database status

![image](https://user-images.githubusercontent.com/12851112/195709638-5a4b9b75-7043-49fa-942d-a9ba9c2b529f.png)

![image](https://user-images.githubusercontent.com/12851112/195704502-442b8c7e-609c-478d-950e-e8f9448d55b9.png)


Depends on:
- [x] https://github.com/ManageIQ/manageiq-appliance_console/pull/195

Required for:
* https://github.com/ManageIQ/manageiq/issues/22132