### PR TITLE
Swap "localhost" to 127.0.0.1 in Messaging server configuration

### DIFF
--- a/lib/manageiq/appliance_console/message_configuration_server.rb
+++ b/lib/manageiq/appliance_console/message_configuration_server.rb
@@ -72,6 +72,11 @@ module ManageIQ
         say("\nMessage Server Parameters:\n\n")
 
         @message_server_host       = ask_for_string("Message Server Hostname or IP address", message_server_host)
+
+        # SSL Validation for Kafka does not work for hostnames containing "localhost"
+        # Therefore we replace with the equivalent IP "127.0.0.1" if a /localhost*/ hostname was entered
+        @message_server_host       = "127.0.0.1" if @message_server_host.include?("localhost")
+
         @message_keystore_username = ask_for_string("Message Keystore Username", message_keystore_username)
         @message_keystore_password = ask_for_password("Message Keystore Password")
         @message_persistent_disk   = ask_for_persistent_disk

--- a/spec/message_configuration_server_spec.rb
+++ b/spec/message_configuration_server_spec.rb
@@ -387,5 +387,33 @@ describe ManageIQ::ApplianceConsole::MessageServerConfiguration do
         expect(subject.message_server_host).to eq("192.0.2.1")
       end
     end
+
+    context "when --message-server-host is specified as localhost*" do
+      before do
+        allow(subject).to receive(:agree).and_return(true)
+        allow(subject).to receive(:host_reachable?).and_return(true)
+        allow(subject).to receive(:message_server_configured?).and_return(true)
+      end
+
+      it "replaces localhost with 127.0.0.1" do
+        expect(subject).to receive(:ask_for_string).with("Message Server Hostname or IP address", anything).and_return("localhost")
+        expect(subject).to receive(:ask_for_string).with("Message Keystore Username", anything).and_return("admin")
+        expect(subject).to receive(:ask_for_password).with("Message Keystore Password").and_return("top_secret")
+        expect(subject).to receive(:ask_for_disk).with("Persistent disk").and_return("/tmp/disk")
+
+        subject.ask_for_parameters
+        expect(subject.message_server_host).to eq("127.0.0.1")
+      end
+
+      it "replaces localhost.localadmin with 127.0.0.1" do
+        expect(subject).to receive(:ask_for_string).with("Message Server Hostname or IP address", anything).and_return("localhost.localadmin")
+        expect(subject).to receive(:ask_for_string).with("Message Keystore Username", anything).and_return("admin")
+        expect(subject).to receive(:ask_for_password).with("Message Keystore Password").and_return("top_secret")
+        expect(subject).to receive(:ask_for_disk).with("Persistent disk").and_return("/tmp/disk")
+
+        subject.ask_for_parameters
+        expect(subject.message_server_host).to eq("127.0.0.1")
+      end
+    end
   end
 end


### PR DESCRIPTION
- resolves https://github.com/ManageIQ/manageiq/issues/22153

```
[root@9-46 ~]# systemctl status kafka
● kafka.service - kafka service
   Loaded: loaded (/usr/lib/systemd/system/kafka.service; enabled; vendor preset: disabled)
   Active: active (running) since Mon 2022-10-17 14:33:38 EDT; 2min 59s ago
 Main PID: 98945 (java)
    Tasks: 76 (limit: 101046)
   Memory: 410.0M
   CGroup: /system.slice/kafka.service
           └─98945 java -Xmx1G -Xms1G -server -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:+ExplicitGCInvokesConcurrent -XX:MaxInlineLevel=15 -Djava.awt.headless=true -Xloggc:/var/log/kafka/kafkaServer-gc.log -verbose:gc -XX:+PrintGCDeta>

Oct 17 14:33:42 9-46.68.56.rtp.raleigh.ibm.com kafka-server-start.sh[98945]: [2022-10-17 14:33:42,460] INFO [GroupMetadataManager brokerId=0] Finished loading offsets and group metadata from __consumer_offsets-12 in 55 milliseconds for epoch 0, of which 55 milliseconds w>
Oct 17 14:33:42 9-46.68.56.rtp.raleigh.ibm.com kafka-server-start.sh[98945]: [2022-10-17 14:33:42,460] INFO [GroupMetadataManager brokerId=0] Finished loading offsets and group metadata from __consumer_offsets-21 in 54 milliseconds for epoch 0, of which 54 milliseconds w>
Oct 17 14:33:42 9-46.68.56.rtp.raleigh.ibm.com kafka-server-start.sh[98945]: [2022-10-17 14:33:42,460] INFO [GroupMetadataManager brokerId=0] Finished loading offsets and group metadata from __consumer_offsets-36 in 54 milliseconds for epoch 0, of which 54 milliseconds w>
Oct 17 14:33:42 9-46.68.56.rtp.raleigh.ibm.com kafka-server-start.sh[98945]: [2022-10-17 14:33:42,460] INFO [GroupMetadataManager brokerId=0] Finished loading offsets and group metadata from __consumer_offsets-6 in 54 milliseconds for epoch 0, of which 54 milliseconds wa>
Oct 17 14:33:42 9-46.68.56.rtp.raleigh.ibm.com kafka-server-start.sh[98945]: [2022-10-17 14:33:42,460] INFO [GroupMetadataManager brokerId=0] Finished loading offsets and group metadata from __consumer_offsets-43 in 54 milliseconds for epoch 0, of which 54 milliseconds w>
Oct 17 14:33:42 9-46.68.56.rtp.raleigh.ibm.com kafka-server-start.sh[98945]: [2022-10-17 14:33:42,460] INFO [GroupMetadataManager brokerId=0] Finished loading offsets and group metadata from __consumer_offsets-13 in 54 milliseconds for epoch 0, of which 54 milliseconds w>
Oct 17 14:33:42 9-46.68.56.rtp.raleigh.ibm.com kafka-server-start.sh[98945]: [2022-10-17 14:33:42,461] INFO [GroupMetadataManager brokerId=0] Finished loading offsets and group metadata from __consumer_offsets-28 in 55 milliseconds for epoch 0, of which 55 milliseconds w>
Oct 17 14:34:27 9-46.68.56.rtp.raleigh.ibm.com kafka-server-start.sh[98945]: [2022-10-17 14:34:27,460] INFO [GroupCoordinator 0]: Member test-a02b10dd-ce44-4c94-8899-32c270556a4e in group manageiq_messaging_queue_group_test-messaging-ready has failed, removing it from th>
Oct 17 14:34:27 9-46.68.56.rtp.raleigh.ibm.com kafka-server-start.sh[98945]: [2022-10-17 14:34:27,466] INFO [GroupCoordinator 0]: Preparing to rebalance group manageiq_messaging_queue_group_test-messaging-ready in state PreparingRebalance with old generation 1 (__consume>
Oct 17 14:34:27 9-46.68.56.rtp.raleigh.ibm.com kafka-server-start.sh[98945]: [2022-10-17 14:34:27,469] INFO [GroupCoordinator 0]: Group manageiq_messaging_queue_group_test-messaging-ready with generation 2 is now empty (__consumer_offsets-2) (kafka.coordinator.group.Grou>

[root@9-46 ~]# systemctl status manageiq-messaging-ready
● manageiq-messaging-ready.service - ManageIQ Messaging Ready
   Loaded: loaded (/usr/lib/systemd/system/manageiq-messaging-ready.service; disabled; vendor preset: disabled)
   Active: inactive (dead) since Mon 2022-10-17 14:32:17 EDT; 4min 54s ago
 Main PID: 96258 (code=exited, status=0/SUCCESS)

Oct 17 14:32:16 9-46.68.56.rtp.raleigh.ibm.com systemd[1]: Starting ManageIQ Messaging Ready...
Oct 17 14:32:17 9-46.68.56.rtp.raleigh.ibm.com manageiq-messaging-ready[96258]: 127.0.0.1 9093 - accepting connections
Oct 17 14:32:17 9-46.68.56.rtp.raleigh.ibm.com manageiq-messaging-ready[96258]: Kafka is up and running
Oct 17 14:32:17 9-46.68.56.rtp.raleigh.ibm.com systemd[1]: manageiq-messaging-ready.service: Succeeded.
Oct 17 14:32:17 9-46.68.56.rtp.raleigh.ibm.com systemd[1]: Started ManageIQ Messaging Ready.
```

@miq-bot add_labels bug
@miq-bot assign @agrare 