### PR TITLE
Release v8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+
+## [8.0.0] - 2022-10-18
+### Fixed
+- Don't require pressing any key twice for message configuration (#193)
+
+### Added
+- Report messaging configuration on summary info page (#190)
+
+### Changed
+- Refactor EvmServer operations (#194)
+- Only start evmserverd after all application configuration is done (#195)
+- **BREAKING** Don't start evmserverd until messaging is configured (#196)
+- Simplify messaging options by saving in yml files (#197)
+
+[Unreleased]: https://github.com/ManageIQ/manageiq-appliance_console/compare/v8.0.0...HEAD
+[8.0.0]: https://github.com/ManageIQ/manageiq-appliance_console/compare/v7.1.1..v8.0.0

--- a/lib/manageiq/appliance_console/version.rb
+++ b/lib/manageiq/appliance_console/version.rb
@@ -1,5 +1,5 @@
 module ManageIQ
   module ApplianceConsole
-    VERSION = '7.1.1'.freeze
+    VERSION = '8.0.0'.freeze
   end
 end


### PR DESCRIPTION
I think we should release an 8.0 so the messaging changes aren't pulled into any current release branches (oparin is on `"~>7.1", ">=7.1.1"` right now).

We didn't have a CHANGELOG here so I added one with the 8.0 changes we can back fill it if we want.

TODO before release:
- [x] https://github.com/ManageIQ/manageiq-appliance_console/pull/197
- [x] https://github.com/ManageIQ/manageiq-appliance_console/pull/198