### PR TITLE
Fix sporadic test failure

### DIFF
--- a/lib/manageiq/appliance_console/database_replication.rb
+++ b/lib/manageiq/appliance_console/database_replication.rb
@@ -151,8 +151,8 @@ Replication Server Configuration
         end
       end
 
-      Process.wait(pid)
-      $CHILD_STATUS.success?
+      pid, status = Process.wait2(pid)
+      status.success?
     end
 
     def primary_connection_hash

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -704,6 +704,8 @@ describe ManageIQ::ApplianceConsole::Cli do
     let(:replication_standby) { ManageIQ::ApplianceConsole::DatabaseReplicationStandby.new }
 
     before do
+      pending "does not work on macOS because `ip` command is not available" if RUBY_PLATFORM.match?(/darwin/)
+
       allow(ManageIQ::ApplianceConsole::DatabaseReplicationPrimary).to receive(:new).and_return(replication_primary)
       allow(ManageIQ::ApplianceConsole::DatabaseReplicationStandby).to receive(:new).and_return(replication_standby)
     end

--- a/spec/database_replication_standby_spec.rb
+++ b/spec/database_replication_standby_spec.rb
@@ -190,8 +190,9 @@ describe ManageIQ::ApplianceConsole::DatabaseReplicationStandby do
           }
         ]
 
-        expect(Process).to receive(:wait).with(1234)
+        expect(Process).to receive(:wait2).with(1234).and_return([1234, double(:success? => true)])
         expect(AwesomeSpawn).to receive(:run!).with(*run_args).and_return(double(:output => "success"))
+
         expect(subject.register_standby_server).to be true
       end
     end


### PR DESCRIPTION
If the cli_spec.rb's set_replication specs ran on macOS before database_replication_standby_spec.rb's register_standby_server specs, the former would create a $CHILD_STATUS var with a failing result. Then when the register_standby_server spec would run it stubs the forking call, but doesn't stub $CHILD_STATUS, resulting in a call to $CHILD_STATUS.success? which would return false.

While we could change the test to also stub $CHILD_STATUS.success? to return true, this only works on Ruby 2.7. On Ruby 3.0 this fails with a modify frozen object error.

Instead, what we can do is use Process.wait2 instead of Process.wait+$CHILD_STATUS.success? This way, we can stub the status object as well.

@agrare Please review.

The following is an example seed that failed for me:

```
SPEC_OPTS="--seed 4884" bundle exec rspec spec/database_replication_standby_spec.rb:195 spec/cli_spec.rb:702
```