### PR TITLE
[WIP] Avoid Readline when in non-tty

### DIFF
--- a/lib/manageiq/appliance_console/database_admin.rb
+++ b/lib/manageiq/appliance_console/database_admin.rb
@@ -127,15 +127,11 @@ module ManageIQ
       end
 
       def should_exclude_tables?
-        ask_yn?("Would you like to exclude tables in the dump") do |q|
-          q.readline = true
-        end
+        ask_yn?("Would you like to exclude tables in the dump")
       end
 
       def should_split_output?
-        ask_yn?("Would you like to split the #{action} output into multiple parts") do |q|
-          q.readline = true
-        end
+        ask_yn?("Would you like to split the #{action} output into multiple parts")
       end
 
       def filename_prompt_args

--- a/lib/manageiq/appliance_console/prompts.rb
+++ b/lib/manageiq/appliance_console/prompts.rb
@@ -195,7 +195,7 @@ module ApplianceConsole
 
     def just_ask(prompt, default = nil, validate = nil, error_text = nil, klass = nil)
       ask("Enter the #{prompt}: ", klass) do |q|
-        q.readline = true
+        q.readline = true if STDIN.tty?
         q.default = default.to_s if default
         q.validate = validate if validate
         q.responses[:not_valid] = error_text ? "Please provide #{error_text}" : "Please provide in the specified format"

--- a/spec/database_admin_spec.rb
+++ b/spec/database_admin_spec.rb
@@ -131,7 +131,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       before do
         subject.instance_variable_set(:@database_opts, {:local_file => uri})
         subject.instance_variable_set(:@delete_agree, true)
-        expect(STDIN).to receive(:getc)
+        expect(input).to receive(:getc)
         allow(File).to receive(:delete)
       end
 
@@ -362,7 +362,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       before do
         subject.instance_variable_set(:@database_opts, {:local_file => uri})
         subject.instance_variable_set(:@delete_agree, true)
-        expect(STDIN).to receive(:getc)
+        expect(input).to receive(:getc)
         allow(File).to receive(:delete)
       end
 
@@ -593,7 +593,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       before do
         subject.instance_variable_set(:@database_opts, {:local_file => uri})
         subject.instance_variable_set(:@delete_agree, true)
-        expect(STDIN).to receive(:getc)
+        expect(input).to receive(:getc)
         allow(File).to receive(:delete)
       end
 

--- a/spec/prompts_spec.rb
+++ b/spec/prompts_spec.rb
@@ -66,7 +66,7 @@ describe ManageIQ::ApplianceConsole::Prompts, :with_ui do
 
   it "should ask for any key" do
     expect(subject).to receive(:say)
-    expect(STDIN).to receive(:getc)
+    expect(input).to receive(:getc)
     subject.press_any_key
   end
 

--- a/spec/support/ui.rb
+++ b/spec/support/ui.rb
@@ -21,6 +21,7 @@ shared_context 'with a terminal ui', :with_ui do
   let(:prompt) { "\n?  " }
 
   before do
+    HighLine.default_instance = HighLine.new(input, output)
     Readline.input = input
     Readline.output = readline_output
   end
@@ -28,6 +29,7 @@ shared_context 'with a terminal ui', :with_ui do
   after do
     @temp_stdin.close! if @temp_stdin
     @temp_stdout.close! if @temp_stdout
+    HighLine.default_instance = HighLine.new(STDIN, STDOUT)
     # best-guess cleanup: Readline has .input=, .output= but no .input, .output
     Readline.input = STDIN
     Readline.output = STDOUT


### PR DESCRIPTION
We have 3 prompt methods. Change all to be more tty friendly:

- any_key: use input and not STDIN
- press_ask_yn: don't use readline (we were sporadic on this support anyway)
- just_ask: only use readline if on a tty.

for ask_yn, we could convert over to all using readln, but this required test changes