### PR TITLE
Remove miq specific source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
-source 'http://rubygems.manageiq.org'
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in manageiq-appliance_console.gemspec


### PR DESCRIPTION
Fixes broken CI failure

We need to have only one main source in a `Gemfile`

```
[DEPRECATED] Your Gemfile contains multiple primary sources.
Using `source` more than once without a block is a security risk, and may result in installing unexpected gems.
To resolve this warning, use a block to indicate which gems should come from the secondary source.
```

- We added this source for `handsoap` dependency in #109 to fix a build failure.
- I'm not able to find when we removed this dependency, and removing it no longer breaks the build.
- Also our `Gemfile.lock` does not mention any manageiq dependencies (besides `manageiq-password`) so I don't see a way we could inadvertently require `handsoap`.
