### PR TITLE
Clean up test output (highline and stdout messages)

### DIFF
--- a/spec/certificate_authority_spec.rb
+++ b/spec/certificate_authority_spec.rb
@@ -33,6 +33,8 @@ describe ManageIQ::ApplianceConsole::CertificateAuthority do
     end
 
     it "should configure http" do
+      # TODO: suppress enabling certmonger to start on reboot
+      expect(subject).to receive(:say).with(/configuring/)
       ipa_configured(true)
       expect_run(/getcert/, anything, response).at_least(3).times
 
@@ -40,7 +42,6 @@ describe ManageIQ::ApplianceConsole::CertificateAuthority do
       expect(LinuxAdmin::Service).to receive(:new).and_return(double(:enable => double(:start => nil)))
       expect(FileUtils).to receive(:chmod).with(0o644, anything)
       allow(ManageIQ::ApplianceConsole::Certificate).to receive(:say)
-      expect(subject).to receive(:say)
       subject.activate
       expect(subject.http).to eq(:complete)
       expect(subject.status_string).to eq("http: complete")

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -693,6 +693,7 @@ describe ManageIQ::ApplianceConsole::Cli do
     end
 
     it "should configure DB as primary when the required arguments are specified" do
+      expect(subject).to receive(:say).with(/Configuring.*Primary/i)
       expect(replication_primary).to receive(:activate)
       subject.parse(%w(--replication primary --cluster-node-number 1 --password pass)).run
       expect(replication_primary.database_name).to eq("vmdb_production")
@@ -702,6 +703,7 @@ describe ManageIQ::ApplianceConsole::Cli do
     end
 
     it "should configure primary replication with a fixed database name and user when specified in the flags" do
+      expect(subject).to receive(:say).with(/Configuring.*Primary/i)
       expect(replication_primary).to receive(:activate)
       subject.parse(%w(--replication primary --cluster-node-number 1 --password pass --dbname vmdb_development --username guest)).run
       expect(replication_primary.database_name).to eq("vmdb_development")
@@ -711,6 +713,7 @@ describe ManageIQ::ApplianceConsole::Cli do
     end
 
     it "should configure DDBB replication as standby when the required parameters are specified" do
+      expect(subject).to receive(:say).with(/Configuring.*Standby/i)
       expect(replication_standby).to receive(:activate)
       subject.parse(%w(--replication standby --cluster-node-number 2 --password pass --dbname vmdb_development --primary-host 10.0.0.1)).run
       expect(replication_standby.disk).to eq(nil)
@@ -722,6 +725,7 @@ describe ManageIQ::ApplianceConsole::Cli do
     end
 
     it "should configure repmgrd when auto-failover flag is set" do
+      expect(subject).to receive(:say).with(/Configuring.*Standby/i)
       expect(subject).to receive(:disk_from_string).with('x').and_return('/dev/x')
       expect(replication_standby).to receive(:activate)
       subject.parse(%w(--replication standby --username dbuser --password pass --cluster-node-number 2 --dbdisk x --primary-host 10.0.0.1 --auto-failover)).run

--- a/spec/database_admin_spec.rb
+++ b/spec/database_admin_spec.rb
@@ -131,7 +131,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       before do
         subject.instance_variable_set(:@database_opts, {:local_file => uri})
         subject.instance_variable_set(:@delete_agree, true)
-        expect(STDIN).to receive(:getc)
+        expect(input).to receive(:getc)
         allow(File).to receive(:delete)
       end
 
@@ -362,7 +362,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       before do
         subject.instance_variable_set(:@database_opts, {:local_file => uri})
         subject.instance_variable_set(:@delete_agree, true)
-        expect(STDIN).to receive(:getc)
+        expect(input).to receive(:getc)
         allow(File).to receive(:delete)
       end
 
@@ -593,7 +593,7 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
       before do
         subject.instance_variable_set(:@database_opts, {:local_file => uri})
         subject.instance_variable_set(:@delete_agree, true)
-        expect(STDIN).to receive(:getc)
+        expect(input).to receive(:getc)
         allow(File).to receive(:delete)
       end
 

--- a/spec/database_configuration_spec.rb
+++ b/spec/database_configuration_spec.rb
@@ -113,12 +113,14 @@ describe ManageIQ::ApplianceConsole::DatabaseConfiguration do
     end
 
     it "normal case" do
+      expect(@config).to receive(:say).with(/Create region.*/i).twice
       expect(@config).not_to receive(:log_and_feedback_exception)
       stub_good_run("rake evm:db:region", :chdir => ManageIQ::ApplianceConsole::RAILS_ROOT, :env => {"REGION" => "42", "VERBOSE" => "false"}, :params => {})
       expect(@config.create_region).to be_truthy
     end
 
     it "failure" do
+      expect(@config).to receive(:say).with(/Create region.*/i).twice
       expect(@config).not_to receive(:log_and_feedback_exception)
       stub_bad_run("rake evm:db:region", :chdir => ManageIQ::ApplianceConsole::RAILS_ROOT, :env => {"REGION" => "42", "VERBOSE" => "false"}, :params => {})
       expect(@config.create_region).to be_falsey

--- a/spec/internal_database_configuration_spec.rb
+++ b/spec/internal_database_configuration_spec.rb
@@ -61,6 +61,7 @@ describe ManageIQ::ApplianceConsole::InternalDatabaseConfiguration do
     end
 
     it "resets the permissions on the postgres users home directory if we mount on top of it" do
+      expect(@config).to receive(:say).twice.with(/Initialize/)
       allow(@config).to receive(:mount_point).and_return(Pathname.new("/var/lib/pgsql"))
       expect(FileUtils).to receive(:chown).with(ManageIQ::ApplianceConsole::PostgresAdmin.user, ManageIQ::ApplianceConsole::PostgresAdmin.group, "/var/lib/pgsql")
       expect(FileUtils).to receive(:chmod).with(0o700, "/var/lib/pgsql")
@@ -69,6 +70,7 @@ describe ManageIQ::ApplianceConsole::InternalDatabaseConfiguration do
     end
 
     it "leaves the mount point alone if it is not the postgres users home directory" do
+      expect(@config).to receive(:say).twice.with(/Initialize/)
       allow(@config).to receive(:mount_point).and_return(Pathname.new("/tmp/pgsql"))
       expect(FileUtils).not_to receive(:chown)
       expect(FileUtils).not_to receive(:chown)

--- a/spec/message_configuration_server_spec.rb
+++ b/spec/message_configuration_server_spec.rb
@@ -363,6 +363,7 @@ describe ManageIQ::ApplianceConsole::MessageServerConfiguration do
       end
 
       it "replaces localhost with 127.0.0.1" do
+        expect(subject).to receive(:say).with(/Message Server Parameters/)
         expect(subject).to receive(:ask_for_string).with("Message Server Hostname or IP address", anything).and_return("localhost")
         expect(subject).to receive(:ask_for_string).with("Message Keystore Username", anything).and_return("admin")
         expect(subject).to receive(:ask_for_password).with("Message Keystore Password").and_return("top_secret")
@@ -373,6 +374,7 @@ describe ManageIQ::ApplianceConsole::MessageServerConfiguration do
       end
 
       it "replaces localhost.localadmin with 127.0.0.1" do
+        expect(subject).to receive(:say).with(/Message Server Parameters/)
         expect(subject).to receive(:ask_for_string).with("Message Server Hostname or IP address", anything).and_return("localhost.localadmin")
         expect(subject).to receive(:ask_for_string).with("Message Keystore Username", anything).and_return("admin")
         expect(subject).to receive(:ask_for_password).with("Message Keystore Password").and_return("top_secret")

--- a/spec/prompts_spec.rb
+++ b/spec/prompts_spec.rb
@@ -66,7 +66,7 @@ describe ManageIQ::ApplianceConsole::Prompts, :with_ui do
 
   it "should ask for any key" do
     expect(subject).to receive(:say)
-    expect(STDIN).to receive(:getc)
+    expect(input).to receive(:getc)
     subject.press_any_key
   end
 

--- a/spec/support/ui.rb
+++ b/spec/support/ui.rb
@@ -29,10 +29,9 @@ shared_context 'with a terminal ui', :with_ui do
   after do
     @temp_stdin.close! if @temp_stdin
     @temp_stdout.close! if @temp_stdout
-    HighLine.default_instance = HighLine.new(STDIN, STDOUT)
-    # best-guess cleanup: Readline has .input=, .output= but no .input, .output
-    Readline.input = STDIN
-    Readline.output = STDOUT
+    HighLine.default_instance = HighLine.new
+    Readline.input = nil
+    Readline.output = nil
   end
 
   # net/ssh messes with track_eof

--- a/spec/support/ui.rb
+++ b/spec/support/ui.rb
@@ -21,6 +21,7 @@ shared_context 'with a terminal ui', :with_ui do
   let(:prompt) { "\n?  " }
 
   before do
+    HighLine.default_instance = HighLine.new(input, output)
     Readline.input = input
     Readline.output = readline_output
   end
@@ -28,6 +29,7 @@ shared_context 'with a terminal ui', :with_ui do
   after do
     @temp_stdin.close! if @temp_stdin
     @temp_stdout.close! if @temp_stdout
+    HighLine.default_instance = HighLine.new(STDIN, STDOUT)
     # best-guess cleanup: Readline has .input=, .output= but no .input, .output
     Readline.input = STDIN
     Readline.output = STDOUT


### PR DESCRIPTION
DEPENDENCY:

- [x] first commit (for 🍏 build) #209

This PR:

- Remove messages printed to stdout in the test run.
- Updating our use of `STDIN` to `input` to be more highline 3.0 (next version) friendly.
