### PR TITLE
Double escape @ in realm to avoid shell interpretation

### DIFF
--- a/lib/manageiq/appliance_console/principal.rb
+++ b/lib/manageiq/appliance_console/principal.rb
@@ -15,7 +15,7 @@ module ApplianceConsole
       options.each { |n, v| public_send("#{n}=", v) }
       @ca_name ||= "ipa"
       @realm = @realm.upcase if @realm
-      @name ||= "#{service}/#{hostname}@#{realm}"
+      @name ||= "#{service}/#{hostname}\\@#{realm}"
     end
 
     def register

--- a/spec/certificate_spec.rb
+++ b/spec/certificate_spec.rb
@@ -23,7 +23,7 @@ describe ManageIQ::ApplianceConsole::Certificate do
 
   # not sure if we care about this (it is probably allowing us to neglect )
   it "should have a principal" do
-    expect(subject.principal.name).to eq("postgres/#{host}@#{realm}")
+    expect(subject.principal.name).to eq("postgres/#{host}\\@#{realm}")
     expect(subject.principal).to be_ipa
   end
 

--- a/spec/principal_spec.rb
+++ b/spec/principal_spec.rb
@@ -3,7 +3,7 @@ describe ManageIQ::ApplianceConsole::Principal do
   let(:hostname) { "machine.network.com" }
   let(:realm)    { "NETWORK.COM" }
   let(:service)  { "postgres" }
-  let(:principal_name) { "postgres/machine.network.com@NETWORK.COM" }
+  let(:principal_name) { "postgres/machine.network.com\\@NETWORK.COM" }
 
   subject { described_class.new(:hostname => hostname, :realm => realm, :service => service) }
 


### PR DESCRIPTION
From:
https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/linux_domain_identity_authentication_and_policy_guide/managing-kerberos-aliases

"When adding or removing enterprise principal aliases, escape the @ symbol using two backslashes (\\). Otherwise, the shell interprets the @ symbol as part of the Kerberos realm name and leads to the following error:
ipa: ERROR: The realm for the principal does not match the realm for this IPA server"

Also mentioned in:
https://www.freeipa.org/page/V4/Kerberos_principal_aliases

"Be careful to escape '@' in the enterprise principal name, otherwise the framework will complain about bad realm"

How to recreate and test this:
1) Deploy a recent new appliance
2) Configure ipa client using the demo environment: https://www.freeipa.org/page/Demo 
3) kinit helpdesk # or any other user configured on the demo env webpage
4) Run appliance_console_cli --http-cert

This recreates realm does not match error above.

Apply this code change allows us to get further but fails because we're not configured to make changes such as adding aliases on the ipa server.