### PR TITLE
Separate kerberos from service principal name and use correctly

### DIFF
--- a/lib/manageiq/appliance_console/principal.rb
+++ b/lib/manageiq/appliance_console/principal.rb
@@ -10,12 +10,14 @@ module ApplianceConsole
     attr_accessor :service
     # kerberos principal name
     attr_accessor :name
+    attr_accessor :service_principal
 
     def initialize(options = {})
       options.each { |n, v| public_send("#{n}=", v) }
       @ca_name ||= "ipa"
       @realm = @realm.upcase if @realm
-      @name ||= "#{service}/#{hostname}\\@#{realm}"
+      @service_principal ||= "#{service}/#{hostname}"
+      @name ||= "#{service_principal}@#{realm}"
     end
 
     def register
@@ -33,13 +35,13 @@ module ApplianceConsole
     private
 
     def exist?
-      AwesomeSpawn.run("/usr/bin/ipa", :params => ["-e", "skip_version_check=1", "service-find", "--principal", name]).success?
+      AwesomeSpawn.run("/usr/bin/ipa", :params => ["-e", "skip_version_check=1", "service-find", "--principal", service_principal]).success?
     end
 
     def request
       # using --force because these services tend not to be in dns
       # this is like VERIFY_NONE
-      AwesomeSpawn.run!("/usr/bin/ipa", :params => ["-e", "skip_version_check=1", "service-add", "--force", name])
+      AwesomeSpawn.run!("/usr/bin/ipa", :params => ["-e", "skip_version_check=1", "service-add", "--force", service_principal])
     end
   end
 end

--- a/spec/certificate_spec.rb
+++ b/spec/certificate_spec.rb
@@ -23,7 +23,7 @@ describe ManageIQ::ApplianceConsole::Certificate do
 
   # not sure if we care about this (it is probably allowing us to neglect )
   it "should have a principal" do
-    expect(subject.principal.name).to eq("postgres/#{host}\\@#{realm}")
+    expect(subject.principal.name).to eq("postgres/#{host}@#{realm}")
     expect(subject.principal).to be_ipa
   end
 

--- a/spec/principal_spec.rb
+++ b/spec/principal_spec.rb
@@ -3,7 +3,8 @@ describe ManageIQ::ApplianceConsole::Principal do
   let(:hostname) { "machine.network.com" }
   let(:realm)    { "NETWORK.COM" }
   let(:service)  { "postgres" }
-  let(:principal_name) { "postgres/machine.network.com\\@NETWORK.COM" }
+  let(:service_principal)  { "postgres/machine.network.com" }
+  let(:kerberos_principal) { "postgres/machine.network.com@NETWORK.COM" }
 
   subject { described_class.new(:hostname => hostname, :realm => realm, :service => service) }
 
@@ -11,19 +12,19 @@ describe ManageIQ::ApplianceConsole::Principal do
   it { expect(subject.realm).to eq(realm) }
   it { expect(subject.service).to eq(service) }
 
-  it { expect(subject.name).to eq(principal_name) }
+  it { expect(subject.name).to eq(kerberos_principal) }
   it { expect(subject.subject_name).to match(/CN=#{hostname}.*O=#{realm}/) }
   it { expect(subject).to be_ipa }
 
   it "should register if not yet registered" do
-    expect_run(/ipa/, ["-e", "skip_version_check=1", "service-find", "--principal", principal_name], response(1))
-    expect_run(/ipa/, ["-e", "skip_version_check=1", "service-add", "--force", principal_name], response)
+    expect_run(/ipa/, ["-e", "skip_version_check=1", "service-find", "--principal", service_principal], response(1))
+    expect_run(/ipa/, ["-e", "skip_version_check=1", "service-add", "--force", service_principal], response)
 
     subject.register
   end
 
   it "should not register if already registered" do
-    expect_run(/ipa/, ["-e", "skip_version_check=1", "service-find", "--principal", principal_name], response)
+    expect_run(/ipa/, ["-e", "skip_version_check=1", "service-find", "--principal", service_principal], response)
 
     subject.register
   end


### PR DESCRIPTION
Fix incomplete fix in #211.

We have two concepts that were being shared.
* kerberos principal name
* service principal name

getcert requires the kerberos principal name with the kerberos realm included: 

`getcert request -K SERVICE/host@REALM`

See https://github.com/ManageIQ/manageiq-appliance_console/blob/9ce14c3087930322bbeac0e2f5a9723d92eea71a/lib/manageiq/appliance_console/certificate.rb#L143-L149 for usage.

ipa service-find and service-add use the service principal name, which doesn't include the kerberos realm as that's assumed based on configuration and cannot be changed without changing the configuration:

`ipa service-find  --principal SERVICE/host`

This commit clarifies these differences and uses the correct mechanism for service-add, service-find, and getcert.

from: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_identity_management/managing-hosts-cli_configuring-and-managing-idm
![Monosnap Chapter 42  Managing Hosts in IdM CLI Red Hat Enterprise Linux 8 | Red Hat Customer Portal 2023-06-22 11-07-03](https://github.com/ManageIQ/manageiq-appliance_console/assets/19339/386624fa-c632-49fc-80ac-3c54776bff34)
