### PR TITLE
Add manageiq user to allowed_uids for sssd

### DIFF
--- a/lib/manageiq/appliance_console/external_httpd_authentication/external_httpd_configuration.rb
+++ b/lib/manageiq/appliance_console/external_httpd_authentication/external_httpd_configuration.rb
@@ -124,7 +124,7 @@ module ApplianceConsole
       def configure_sssd_ifp(config)
         user_attributes = LDAP_ATTRS.keys.collect { |k| "+#{k}" }.join(", ")
         ifp_config      = "
-  allowed_uids = #{APACHE_USER}, root
+  allowed_uids = #{APACHE_USER}, root, manageiq
   user_attributes = #{user_attributes}
 "
         if config.include?("[ifp]")


### PR DESCRIPTION
When we moved to using a manageiq user, we need to add this user so it has permission in sssd.conf.

See also https://github.com/ManageIQ/manageiq-documentation/pull/1743