### PR TITLE
Both pg_dump and pg_basebackup are supported ways to backup the database

### DIFF
--- a/lib/manageiq/appliance_console/database_admin.rb
+++ b/lib/manageiq/appliance_console/database_admin.rb
@@ -15,14 +15,6 @@ module ManageIQ
         Example: 'mydomain.com/user'
       PROMPT
 
-      DB_DUMP_WARNING = <<-WARN.strip_heredoc
-        WARNING:  This is not the recommended and supported way of running a
-        database backup, and is strictly meant for exporting a database for
-        support/debugging purposes!
-
-
-      WARN
-
       attr_reader :action, :backup_type, :database_opts, :delete_agree, :filename
 
       def initialize(action = :restore, input = $stdin, output = $stdout)
@@ -43,7 +35,6 @@ module ManageIQ
           press_any_key
           raise MiqSignalError
         end
-        say(DB_DUMP_WARNING) if action == :dump
         ask_file_location
         ask_for_tables_to_exclude_in_dump
       end

--- a/spec/database_admin_spec.rb
+++ b/spec/database_admin_spec.rb
@@ -461,39 +461,12 @@ describe ManageIQ::ApplianceConsole::DatabaseAdmin, :with_ui do
     subject { described_class.new(:dump, input, output) }
 
     describe "#ask_questions" do
-      let(:pg_dump_warning) do
-        <<-WARN.strip_heredoc
-          WARNING:  This is not the recommended and supported way of running a
-          database backup, and is strictly meant for exporting a database for
-          support/debugging purposes!
-
-
-        WARN
-      end
-
-      it "warns about using pg_dump and asks for file location" do
+      it "asks for file location and tables to exclude" do
         expect(subject).to receive(:say).with("Create Database Dump\n\n")
-        expect(subject).to receive(:say).with(pg_dump_warning)
         expect(subject).to receive(:ask_file_location)
         expect(subject).to receive(:ask_for_tables_to_exclude_in_dump)
 
         subject.ask_questions
-      end
-
-      it "has proper formatting for the pg_dump warning" do
-        allow(subject).to receive(:ask_file_location)
-        allow(subject).to receive(:ask_for_tables_to_exclude_in_dump)
-        subject.ask_questions
-
-        expect_output <<-PROMPT.strip_heredoc
-          Create Database Dump
-
-          WARNING:  This is not the recommended and supported way of running a
-          database backup, and is strictly meant for exporting a database for
-          support/debugging purposes!
-
-
-        PROMPT
       end
     end
 


### PR DESCRIPTION
There are pros and cons to both logical and physical backups and in fact people should probably plan on doing both types of backups.

Physical/pg_dump for table or database exports for testing, upgrades, and for disaster recovery. It's slower but generally smaller.

Logical/pg_basebackup for cluster backups and versatility to restore from point in time or from standbys. It's also much faster.

See also:
https://www.enterprisedb.com/postgresql-database-backup-recovery-what-works-wal-pitr