### PR TITLE
Fix specs where AwesomeSpawn private interface changed

### DIFF
--- a/manageiq-appliance_console.gemspec
+++ b/manageiq-appliance_console.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "activerecord",            "~> 6.1.6", ">= 6.1.6.1"
   spec.add_runtime_dependency "activesupport",           "~> 6.1.6", ">= 6.1.6.1"
-  spec.add_runtime_dependency "awesome_spawn",           "~> 1.4"
+  spec.add_runtime_dependency "awesome_spawn",           "~> 1.6"
   spec.add_runtime_dependency "bcrypt",                  "~> 3.1.10"
   spec.add_runtime_dependency "bcrypt_pbkdf",            ">= 1.0", "< 2.0"
   spec.add_runtime_dependency "highline",                "~> 2.1"

--- a/spec/certificate_spec.rb
+++ b/spec/certificate_spec.rb
@@ -118,6 +118,6 @@ describe ManageIQ::ApplianceConsole::Certificate do
   end
 
   def response(ret_code = 0)
-    AwesomeSpawn::CommandResult.new("cmd", "output", "", ret_code)
+    AwesomeSpawn::CommandResult.new("cmd", "output", "", nil, ret_code)
   end
 end

--- a/spec/principal_spec.rb
+++ b/spec/principal_spec.rb
@@ -42,6 +42,6 @@ describe ManageIQ::ApplianceConsole::Principal do
   end
 
   def response(ret_code = 0)
-    AwesomeSpawn::CommandResult.new("cmd", "output", "", ret_code)
+    AwesomeSpawn::CommandResult.new("cmd", "output", "", nil, ret_code)
   end
 end


### PR DESCRIPTION
AwesomeSpawn 1.6 changed the interface to the AwesomeSpawn::CommandResult which is an internal interface, but was used directly by specs.

@agrare Please review.