### PR TITLE
Allow rails 7 gems in gemspec

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,9 @@ jobs:
       matrix:
         ruby-version:
         - '3.0'
+        rails-version:
+        - '6.1'
+        - '7.0'
     services:
       postgres:
         image: manageiq/postgresql:13
@@ -26,6 +29,7 @@ jobs:
     env:
       PGHOST: localhost
       PGPASSWORD: smartvm
+      TEST_RAILS_VERSION: ${{ matrix.rails-version }}
       CC_TEST_REPORTER_ID: "${{ secrets.CC_TEST_REPORTER_ID }}"
     steps:
     - uses: actions/checkout@v4
@@ -37,6 +41,6 @@ jobs:
     - name: Run tests
       run: bundle exec rake
     - name: Report code coverage
-      if: "${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '3.0' }}"
+      if: "${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '3.0' && matrix.rails-version == '6.1' }}"
       continue-on-error: true
       uses: paambaati/codeclimate-action@v5

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,14 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in manageiq-appliance_console.gemspec
 gemspec
+
+minimum_version =
+  case ENV['TEST_RAILS_VERSION']
+  when "7.0"
+    "~>7.0.8"
+  else
+    "~>6.1.4"
+  end
+
+gem "activerecord", minimum_version
+gem "activesupport", minimum_version

--- a/manageiq-appliance_console.gemspec
+++ b/manageiq-appliance_console.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activerecord",            "~> 6.1.6", ">= 6.1.6.1"
-  spec.add_runtime_dependency "activesupport",           "~> 6.1.6", ">= 6.1.6.1"
+  spec.add_runtime_dependency "activerecord",            ">=6.1.7.6"
+  spec.add_runtime_dependency "activesupport",           ">=6.1.7.6"
   spec.add_runtime_dependency "awesome_spawn",           "~> 1.6"
   spec.add_runtime_dependency "bcrypt",                  "~> 3.1.10"
   spec.add_runtime_dependency "bcrypt_pbkdf",            ">= 1.0", "< 2.0"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,3 +38,9 @@ RSpec.configure do |config|
     config.add_setting :with_postgres_specs, :default => false
   end
 end
+
+require "active_record"
+require "active_support"
+puts
+puts "\e[93mUsing ActiveRecord #{ActiveRecord.version}\e[0m"
+puts "\e[93mUsing ActiveSupport #{ActiveSupport.version}\e[0m"


### PR DESCRIPTION
Allow rails 7 gems in gemspec

The tests don't pull in manageiq, so I was able to add rails 7 to the test matrix.