### PR TITLE
Add ruby 3.1 to the test matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         ruby-version:
         - '3.0'
+        - '3.1'
         rails-version:
         - '6.1'
         - '7.0'

--- a/lib/manageiq/appliance_console/message_configuration.rb
+++ b/lib/manageiq/appliance_console/message_configuration.rb
@@ -110,7 +110,13 @@ module ManageIQ
 
         return if file_found?(messaging_yaml_path)
 
-        messaging_yaml = YAML.load_file(messaging_yaml_sample_path)
+        data = File.read(messaging_yaml_sample_path)
+        messaging_yaml =
+          if YAML.respond_to?(:safe_load)
+            YAML.safe_load(data, :aliases => true)
+          else
+            YAML.load(data) # rubocop:disable Security/YAMLLoad
+          end
 
         messaging_yaml["production"]["host"]      = message_server_host
         messaging_yaml["production"]["port"]      = message_server_port


### PR DESCRIPTION
Load aliases with safe_load if YAML supports it.

Disable YAML.load security cop on versions that don't have safe_load.