### PR TITLE
Fix YAML.load_file failing on aliases

### DIFF
--- a/lib/manageiq/appliance_console/database_configuration.rb
+++ b/lib/manageiq/appliance_console/database_configuration.rb
@@ -257,7 +257,13 @@ FRIENDLY
         require 'fileutils'
         FileUtils.cp(DB_YML_TMPL, DB_YML) if File.exist?(DB_YML_TMPL)
       end
-      YAML.load_file(DB_YML)
+
+      data = File.read(DB_YML)
+      if YAML.respond_to?(:safe_load)
+        YAML.safe_load(data, :aliases => true)
+      else
+        YAML.load(data) # rubocop:disable Security/YAMLLoad
+      end
     end
 
     def validate_encryption_key!


### PR DESCRIPTION
Fix configuring an internal database with ruby 3.1 failing due to aliases in the `config/database.pg.yml` file

```
/opt/manageiq/manageiq-gemset/gems/psych-4.0.6/lib/psych/visitors/to_ruby.rb:432:in 'visit_Psych_Nodes_Alias': Unknown alias: base (Psych::BadAlias)
```

Fixes https://github.com/ManageIQ/manageiq-appliance_console/issues/232
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
