### PR TITLE
Enable evmserver after configuring db and messaging

### DIFF
--- a/bin/appliance_console
+++ b/bin/appliance_console
@@ -312,7 +312,7 @@ To modify the configuration, use a web browser to access the management page.
         # Start evmserverd if database and/or messaging were set up and we are supposed to run as an evmserver
         if changes_requested && database_configuration.run_as_evm_server
           say("\nStarting #{I18n.t("product.name")} Server...")
-          ManageIQ::ApplianceConsole::EvmServer.start
+          ManageIQ::ApplianceConsole::EvmServer.start(:enable => true)
         end
 
         press_any_key


### PR DESCRIPTION
When starting EvmServer after having configured the database and messaging we should enable the service so it starts on boot

Before:
```
[root@manageiq-devel ~]# systemctl status evmserverd.service
● evmserverd.service - EVM server daemon
     Loaded: loaded (/usr/lib/systemd/system/evmserverd.service; disabled; preset: disabled)
     Active: active (running) since Fri 2024-03-08 10:08:04 EST; 49s ago
   Main PID: 5333 (ruby)
      Tasks: 14 (limit: 48891)
     Memory: 597.7M
        CPU: 20.886s
     CGroup: /system.slice/evmserverd.service
             └─5333 "MIQ Server"
```

After:
```
[root@manageiq-devel ~]# systemctl status evmserverd.service
● evmserverd.service - EVM server daemon
     Loaded: loaded (/usr/lib/systemd/system/evmserverd.service; enabled; preset: disabled)
     Active: active (running) since Fri 2024-03-08 10:24:18 EST; 8s ago
   Main PID: 5329 (ruby)
      Tasks: 7 (limit: 48891)
     Memory: 333.6M
        CPU: 6.607s
     CGroup: /system.slice/evmserverd.service
             ├─5329 "MIQ Server"
             └─5368 top -b -n 1
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
