### PR TITLE
Fix missing i18n with appliance_console_cli

### DIFF
--- a/bin/appliance_console_cli
+++ b/bin/appliance_console_cli
@@ -4,4 +4,5 @@ require 'bundler'
 Bundler.setup
 
 require 'manageiq/appliance_console'
+require 'manageiq/appliance_console/i18n'
 ManageIQ::ApplianceConsole::Cli.parse(ARGV)


### PR DESCRIPTION
When using appliance_console_cli i18n wasn't required so any translated strings fail to be printed properly.

Before:
```
# appliance_console_cli --server start
Cannot start Translation missing: en.product.name: Messaging has not been configured.
```

After:
```
# appliance_console_cli --server start
Cannot start ManageIQ: Messaging has not been configured.
```

Fixes https://github.com/ManageIQ/manageiq-appliance_console/issues/246
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
