### PR TITLE
Fix missing kafka client ca-cert

### DIFF
--- a/lib/manageiq/appliance_console/message_configuration_client.rb
+++ b/lib/manageiq/appliance_console/message_configuration_client.rb
@@ -29,6 +29,7 @@ module ManageIQ
           configure_messaging_yaml          # Set up the local message client in case EVM is actually running on this, Message Server
           create_client_properties          # Create the client.properties configuration fle
           fetch_truststore_from_server      # Fetch the Java Keystore from the Kafka Server
+          fetch_ca_cert_from_server         # Fetch the CA Certificate from the Kafka Server
         rescue AwesomeSpawn::CommandResultError => e
           say(e.result.output)
           say(e.result.error)


### PR DESCRIPTION
When configuring an appliance as a kafka client the user is asked for the truststore path as well as the ca certificate path from the kafka broker.  The truststore is scp'd over but the ca-cert is not causing kafka connections to fail

`manageiq-messaging-ready`:
```
manageiq-db.localdomain 9093 - accepting connections
ssl.ca.location failed: error:05880002:x509 certificate routines::system lib
Kafka is not ready yet
```

After manually scp-ing the ca-cert over manageiq-messaging-ready connected successfully and evmserverd started up.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
