### PR TITLE
Messaging Hostname Validation

### DIFF
--- a/lib/manageiq/appliance_console/message_configuration_client.rb
+++ b/lib/manageiq/appliance_console/message_configuration_client.rb
@@ -46,7 +46,7 @@ module ManageIQ
       def ask_for_parameters
         say("\nMessage Client Parameters:\n\n")
 
-        @message_server_host         = ask_for_string("Message Server Hostname or IP address")
+        @message_server_host         = ask_for_messaging_hostname("Message Server Hostname")
         @message_server_port         = ask_for_integer("Message Server Port number", (1..65_535), 9_093).to_i
         @message_server_username     = ask_for_string("Message Server Username", message_server_username)
         @message_server_password     = ask_for_password("Message Server Password")

--- a/lib/manageiq/appliance_console/message_configuration_server.rb
+++ b/lib/manageiq/appliance_console/message_configuration_server.rb
@@ -68,11 +68,7 @@ module ManageIQ
       def ask_for_parameters
         say("\nMessage Server Parameters:\n\n")
 
-        @message_server_host       = ask_for_string("Message Server Hostname or IP address", message_server_host)
-
-        # SSL Validation for Kafka does not work for hostnames containing "localhost"
-        # Therefore we replace with the equivalent IP "127.0.0.1" if a /localhost*/ hostname was entered
-        @message_server_host       = "127.0.0.1" if @message_server_host.include?("localhost")
+        @message_server_host       = ask_for_messaging_hostname("Message Server Hostname", message_server_host)
 
         @message_keystore_username = ask_for_string("Message Keystore Username", message_keystore_username)
         @message_keystore_password = ask_for_new_password("Message Keystore Password")
@@ -301,13 +297,8 @@ module ManageIQ
                            "-genkey"   => nil,
                            "-keyalg"   => "RSA"}
 
-        if message_server_host.ipaddress?
-          keystore_params["-alias"] = "localhost"
-          keystore_params["-ext"] = "san=ip:#{message_server_host}"
-        else
-          keystore_params["-alias"] = message_server_host
-          keystore_params["-ext"] = "san=dns:#{message_server_host}"
-        end
+        keystore_params["-alias"] = message_server_host
+        keystore_params["-ext"] = "san=dns:#{message_server_host}"
 
         keystore_params["-dname"] = "cn=#{keystore_params["-alias"]}"
 

--- a/lib/manageiq/appliance_console/prompts.rb
+++ b/lib/manageiq/appliance_console/prompts.rb
@@ -14,6 +14,7 @@ module ApplianceConsole
     INT_REGEXP    = /^[0-9]+$/
     NONE_REGEXP   = /^('?NONE'?)?$/i.freeze
     HOSTNAME_REGEXP = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/.freeze
+    MESSAGING_HOSTNAME_REGEXP = /^(?!.*localhost)(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/.freeze
 
     def ask_for_uri(prompt, expected_scheme, opts = {})
       require 'uri'
@@ -69,6 +70,11 @@ module ApplianceConsole
 
     def ask_for_hostname(prompt, default = nil, validate = HOSTNAME_REGEXP, error_text = "a valid Hostname.", &block)
       just_ask(prompt, default, validate, error_text, &block)
+    end
+
+    def ask_for_messaging_hostname(prompt, default = nil, error_text = "a valid Messaging Hostname (not an IP or localhost)", &block)
+      validation = ->(h) { h =~ MESSAGING_HOSTNAME_REGEXP && h !~ IP_REGEXP }
+      just_ask(prompt, default, validation, error_text, &block)
     end
 
     def ask_for_ip_or_hostname(prompt, default = nil)

--- a/spec/message_configuration_client_spec.rb
+++ b/spec/message_configuration_client_spec.rb
@@ -40,12 +40,13 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
   describe "#ask_questions" do
     before do
       allow(subject).to receive(:agree).and_return(true)
+      allow(subject).to receive(:host_resolvable?).and_return(true)
       allow(subject).to receive(:host_reachable?).and_return(true)
       allow(subject).to receive(:message_client_configured?).and_return(false)
     end
 
     it "should prompt for message_keystore_username and message_keystore_password" do
-      expect(subject).to receive(:ask_for_string).with("Message Server Hostname or IP address").and_return("my-host-name.example.com")
+      expect(subject).to receive(:ask_for_messaging_hostname).with("Message Server Hostname").and_return("my-host-name.example.com")
       expect(subject).to receive(:ask_for_integer).with("Message Server Port number", (1..65_535), 9_093).and_return("9093")
       expect(subject).to receive(:ask_for_string).with("Message Keystore Username", message_keystore_username).and_return("admin")
       expect(subject).to receive(:ask_for_password).with("Message Keystore Password").and_return("top_secret")
@@ -61,7 +62,7 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
     end
 
     it "should display Server Hostname and Key Username" do
-      allow(subject).to receive(:ask_for_string).with("Message Server Hostname or IP address").and_return("my-kafka-server.example.com")
+      allow(subject).to receive(:ask_for_messaging_hostname).with("Message Server Hostname").and_return("my-kafka-server.example.com")
       allow(subject).to receive(:ask_for_integer).with("Message Server Port number", (1..65_535), 9_093).and_return("9093")
       allow(subject).to receive(:ask_for_string).with("Message Keystore Username", message_keystore_username).and_return("admin")
       allow(subject).to receive(:ask_for_password).with("Message Keystore Password").and_return("top_secret")


### PR DESCRIPTION
- reject IPs and localhost entries when prompted for messaging hostname
- check if hostname is resolvable alongside reachability after prompts

@miq-bot assign @agrare 
@miq-bot add_reviewer @agrare 
@miq-bot add_label enhancement