### PR TITLE
Messaging keystore password validation

### DIFF
--- a/lib/manageiq/appliance_console/message_configuration_client.rb
+++ b/lib/manageiq/appliance_console/message_configuration_client.rb
@@ -53,7 +53,7 @@ module ManageIQ
         @message_truststore_path_src = ask_for_string("Message Server Truststore Path", truststore_path)
         @message_ca_cert_path_src    = ask_for_string("Message Server CA Cert Path", ca_cert_path)
         @message_keystore_username   = ask_for_string("Message Keystore Username", message_keystore_username) if secure?
-        @message_keystore_password   = ask_for_password("Message Keystore Password") if secure?
+        @message_keystore_password   = ask_for_messaging_password("Message Keystore Password") if secure?
       end
 
       def show_parameters

--- a/lib/manageiq/appliance_console/message_configuration_server.rb
+++ b/lib/manageiq/appliance_console/message_configuration_server.rb
@@ -71,7 +71,7 @@ module ManageIQ
         @message_server_host       = ask_for_messaging_hostname("Message Server Hostname", message_server_host)
 
         @message_keystore_username = ask_for_string("Message Keystore Username", message_keystore_username)
-        @message_keystore_password = ask_for_new_password("Message Keystore Password")
+        @message_keystore_password = ask_for_messaging_password("Message Keystore Password")
         @message_persistent_disk   = ask_for_persistent_disk
       end
 

--- a/spec/message_configuration_client_spec.rb
+++ b/spec/message_configuration_client_spec.rb
@@ -49,7 +49,7 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
       expect(subject).to receive(:ask_for_messaging_hostname).with("Message Server Hostname").and_return("my-host-name.example.com")
       expect(subject).to receive(:ask_for_integer).with("Message Server Port number", (1..65_535), 9_093).and_return("9093")
       expect(subject).to receive(:ask_for_string).with("Message Keystore Username", message_keystore_username).and_return("admin")
-      expect(subject).to receive(:ask_for_password).with("Message Keystore Password").and_return("top_secret")
+      expect(subject).to receive(:ask_for_messaging_password).with("Message Keystore Password").and_return("top_secret")
       expect(subject).to receive(:ask_for_string).with("Message Server Truststore Path", subject.truststore_path)
       expect(subject).to receive(:ask_for_string).with("Message Server CA Cert Path", subject.ca_cert_path)
 
@@ -65,7 +65,7 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
       allow(subject).to receive(:ask_for_messaging_hostname).with("Message Server Hostname").and_return("my-kafka-server.example.com")
       allow(subject).to receive(:ask_for_integer).with("Message Server Port number", (1..65_535), 9_093).and_return("9093")
       allow(subject).to receive(:ask_for_string).with("Message Keystore Username", message_keystore_username).and_return("admin")
-      allow(subject).to receive(:ask_for_password).with("Message Keystore Password").and_return("top_secret")
+      allow(subject).to receive(:ask_for_messaging_password).with("Message Keystore Password").and_return("top_secret")
       allow(subject).to receive(:ask_for_string).with("Message Server Truststore Path", subject.truststore_path)
       allow(subject).to receive(:ask_for_string).with("Message Server CA Cert Path", subject.ca_cert_path)
 


### PR DESCRIPTION
During appliance install, when using a messaging keystore password with special characters the appliance setup will fail. This appears to be a JKS (Java Keystore) limitation and should be addressed by preventing entry of passwords with special characters

@miq-bot assign @agrare 
@miq-bot add_label bug
@miq-bot add_reviewer @agrare 