### PR TITLE
State messaging disk is optional

### DIFF
--- a/lib/manageiq/appliance_console/message_configuration_server.rb
+++ b/lib/manageiq/appliance_console/message_configuration_server.rb
@@ -80,7 +80,7 @@ module ManageIQ
       end
 
       def use_new_disk
-        agree("Configure a new persistent disk volume? (Y/N): ")
+        agree("Configure a new persistent disk volume? (optional) (Y/N): ")
       end
 
       def choose_disk


### PR DESCRIPTION
Users have reported confusion as to whether this is mandatory or not, its a good idea to explicitly state that this is optional.
Following the doc update https://github.com/ManageIQ/manageiq-documentation/pull/1798

@miq-bot assign @agrare 
@miq-bot add_label enhancement
@miq-bot add_reviewer @agrare 
