### PR TITLE
Deprecate message-server-use-ipaddr option from CLI

### DIFF
--- a/lib/manageiq/appliance_console/cli.rb
+++ b/lib/manageiq/appliance_console/cli.rb
@@ -216,20 +216,16 @@ module ApplianceConsole
         opt :message_server_username,     "Message Server Username",                                        :type => :string
         opt :message_server_password,     "Message Server password",                                        :type => :string
         opt :message_server_port,         "Message Server Port",                                            :type => :integer
-        opt :message_server_use_ipaddr,   "Message Server Use Address",                                     :type => :boolean, :default => false
+        opt :message_server_use_ipaddr,   "Deprecated: Message Server Use Address",                         :type => :boolean, :default => false
         opt :message_server_host,         "Message Server Hostname or IP Address",                          :type => :string
         opt :message_truststore_path_src, "Message Server Truststore Path",                                 :type => :string
         opt :message_ca_cert_path_src,    "Message Server CA Cert Path",                                    :type => :string
         opt :message_persistent_disk,     "Message Persistent Disk Path",                                   :type => :string
       end
       Optimist.die :region, "needed when setting up a local database" if region_number_required? && options[:region].nil?
-      Optimist.die "Supply only one of --message-server-host or --message-server-use-ipaddr=true" if both_host_and_use_ip_addr_specified?
       Optimist.die "Supply only one of --message-server-config, --message-server-unconfig, --message-client-config or --message-client-unconfig" if multiple_message_subcommands?
+      warn("--message_server_use_ipaddr is deprecated and will be ignored") if options[:message_server_use_ipaddr]
       self
-    end
-
-    def both_host_and_use_ip_addr_specified?
-      !options[:message_server_host].nil? && options[:message_server_use_ipaddr] == true
     end
 
     def multiple_message_subcommands?

--- a/lib/manageiq/appliance_console/message_configuration_server.rb
+++ b/lib/manageiq/appliance_console/message_configuration_server.rb
@@ -17,7 +17,7 @@ module ManageIQ
       def initialize(options = {})
         super(options)
 
-        @message_server_host           = options[:message_server_use_ipaddr] == true ? my_ipaddr : options[:message_server_host] || my_hostname
+        @message_server_host           = options[:message_server_host] || my_hostname
         @message_persistent_disk       = LinuxAdmin::Disk.new(:path => options[:message_persistent_disk]) unless options[:message_persistent_disk].nil?
 
         @jaas_config_path              = config_dir_path.join("kafka_server_jaas.conf")

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -16,10 +16,6 @@ describe ManageIQ::ApplianceConsole::Cli do
       expect { subject.parse(%w[--message-server-config --message-server-unconfig]) }.to raise_error(OptimistDieSpecError)
     end
 
-    it "fails if both a message server host and use ip addres are specified" do
-      expect { subject.parse(%w[--message-server-config --message-server-host my_host_name --message-server-use-ipaddr]) }.to raise_error(OptimistDieSpecError)
-    end
-
     it "fails if message client config and unconfig subcommands are specified" do
       expect { subject.parse(%w[--message-client-config --message-client-unconfig]) }.to raise_error(OptimistDieSpecError)
     end
@@ -800,15 +796,6 @@ describe ManageIQ::ApplianceConsole::Cli do
           .with(hash_including(:message_server_host => "server.example.com", :message_keystore_username => "user", :message_keystore_password => "pass"))
           .and_return(message_server)
         subject.parse(%w[--message-server-config --message-server-host server.example.com --message-keystore-username user --message-keystore-password pass]).run
-      end
-
-      it "should initiate Message Server config with ip addr" do
-        message_server = double
-        expect(message_server).to receive(:configure)
-        expect(ManageIQ::ApplianceConsole::MessageServerConfiguration).to receive(:new)
-          .with(hash_including(:message_server_use_ipaddr => true, :message_keystore_username => "user", :message_keystore_password => "pass"))
-          .and_return(message_server)
-        subject.parse(%w[--message-server-config --message-server-use-ipaddr true --message-keystore-username user --message-keystore-password pass]).run
       end
 
       it "should initiate Message Server config with persistent disk" do

--- a/spec/message_configuration_server_spec.rb
+++ b/spec/message_configuration_server_spec.rb
@@ -321,19 +321,7 @@ describe ManageIQ::ApplianceConsole::MessageServerConfiguration do
   end
 
   describe "#initialize" do
-    context "when --message-server-use-ipaddr is specified" do
-      subject { described_class.new(:message_keystore_username => message_keystore_username, :message_keystore_password => message_keystore_password, :message_server_use_ipaddr => true) }
-
-      it "sets message_server_host to my ip address" do
-        ip_address = LinuxAdmin::IpAddress.new
-        expect(ip_address).to receive(:address).and_return("192.0.2.0")
-        expect(LinuxAdmin::IpAddress).to receive(:new).and_return(ip_address)
-
-        expect(subject.message_server_host).to eq("192.0.2.0")
-      end
-    end
-
-    context "when neither --message-server-use-ipaddr or --message-server-host are specified" do
+    context "when --message-server-host is not specified" do
       subject { described_class.new(:message_keystore_username => message_keystore_username, :message_keystore_password => message_keystore_password) }
 
       it "sets message_server_host to my hostname" do


### PR DESCRIPTION
We no longer allow IPs to be used for messaging hosts and so the `message-server-use-ipaddr` option in the CLI should be deprecated

@miq-bot assign @agrare 
@miq-bot add_label bug
@miq-bot add_reviewer @agrare 
