### PR TITLE
Add ca-cert to messaging client installed_files

### DIFF
--- a/lib/manageiq/appliance_console/message_configuration_client.rb
+++ b/lib/manageiq/appliance_console/message_configuration_client.rb
@@ -20,7 +20,7 @@ module ManageIQ
         @message_truststore_path_src = options[:message_truststore_path_src] || truststore_path
         @message_ca_cert_path_src    = options[:message_ca_cert_path_src] || ca_cert_path
 
-        @installed_files = [client_properties_path, messaging_yaml_path, truststore_path]
+        @installed_files = [client_properties_path, messaging_yaml_path, truststore_path, ca_cert_path]
       end
 
       def configure


### PR DESCRIPTION
Seems like `ca-cert` was missed in being added to the list of installed files when configuring a messaging client. As a result the ca-cert was not being removed when unconfiguring messaging. This results in an issue with stale ca-certs, see https://github.com/ManageIQ/manageiq-appliance_console/issues/253

@miq-bot assign @agrare 
@miq-bot add_label bug
@miq-bot add_reviewer @agrare 