### PR TITLE
Don't depend on eth0 for displaying network information

### DIFF
--- a/bin/appliance_console
+++ b/bin/appliance_console
@@ -72,13 +72,13 @@ RE_RESTART  = "Restart".freeze
 RE_DELLOGS  = "Restart and Clean Logs".freeze
 RE_OPTIONS  = [RE_RESTART, RE_DELLOGS, ManageIQ::ApplianceConsole::CANCEL].freeze
 
-NETWORK_INTERFACE = "eth0".freeze
 CLOUD_INIT_NETWORK_CONFIG_FILE = "/etc/cloud/cloud.cfg.d/99_miq_disable_network_config.cfg".freeze
 CLOUD_INIT_DISABLE_NETWORK_CONFIG = "network: {config: disabled}\n".freeze
 
 module ManageIQ
 module ApplianceConsole
-  eth0 = LinuxAdmin::NetworkInterface.new(NETWORK_INTERFACE)
+  # Get a list of network interfaces
+  nics = LinuxAdmin::NetworkInterface.list.reject(&:loopback?)
   # Because it takes a few seconds, get the region once in the outside loop
   region = ManageIQ::ApplianceConsole::DatabaseConfiguration.region
 
@@ -88,15 +88,8 @@ module ApplianceConsole
 
   loop do
     begin
-      dns = LinuxAdmin::Dns.new
-      eth0.reload
-      eth0.parse_conf if eth0.respond_to?(:parse_conf)
-
+      dns              = LinuxAdmin::Dns.new
       host             = LinuxAdmin::Hosts.new.hostname
-      ip               = eth0.address
-      mac              = eth0.mac_address
-      mask             = eth0.netmask
-      gw               = eth0.gateway
       dns1, dns2       = dns.nameservers
       order            = dns.search_order.join(' ')
       timezone         = LinuxAdmin::TimeDate.system_timezone
@@ -113,16 +106,25 @@ module ApplianceConsole
         "not configured"
       end
 
-      summary_attributes = [
-        summary_entry("Hostname", host),
-        summary_entry("IPv4 Address", "#{ip}/#{mask}"),
-        summary_entry("IPv4 Gateway", gw),
-        summary_entry("IPv6 Address", eth0.address6 ? "#{eth0.address6}/#{eth0.prefix6}" : ''),
-        summary_entry("IPV6 Gateway", eth0.gateway6),
+      summary_attributes = [summary_entry("Hostname", host)]
+
+      nics.each(&:reload)
+      nics.each do |nic|
+        next if nic.address.nil? && nic.address6.nil?
+
+        summary_attributes += [
+          summary_entry("#{nic.interface} IPv4 Address", "#{nic.address}/#{nic.prefix}"),
+          summary_entry("#{nic.interface} IPv4 Gateway", nic.gateway),
+          summary_entry("#{nic.interface} IPv6 Address", nic.address6 ? "#{nic.address6}/#{nic.prefix6}" : ""),
+          summary_entry("#{nic.interface} IPv6 Gateway", nic.gateway6),
+          summary_entry("#{nic.interface} MAC Address", nic.mac_address)
+        ]
+      end
+
+      summary_attributes += [
         summary_entry("Primary DNS", dns1),
         summary_entry("Secondary DNS", dns2),
         summary_entry("Search Order", order),
-        summary_entry("MAC Address", mac),
         summary_entry("Timezone", timezone),
         summary_entry("Local Database Server", PostgresAdmin.local_server_status),
         summary_entry("#{I18n.t("product.name")} Server", evm_status),

--- a/lib/manageiq/appliance_console/database_replication.rb
+++ b/lib/manageiq/appliance_console/database_replication.rb
@@ -25,6 +25,10 @@ module ApplianceConsole
     attr_accessor :node_number, :database_name, :database_user,
                   :database_password, :primary_host
 
+    def network_interfaces
+      @network_interfaces ||= LinuxAdmin::NetworkInterface.list.reject(&:loopback?)
+    end
+
     def ask_for_unique_cluster_node_number
       self.node_number = ask_for_integer("number uniquely identifying this node in the replication cluster")
     end

--- a/lib/manageiq/appliance_console/database_replication_primary.rb
+++ b/lib/manageiq/appliance_console/database_replication_primary.rb
@@ -10,7 +10,7 @@ module ApplianceConsole
       self.database_name     = "vmdb_production"
       self.database_user     = "root"
       self.database_password = nil
-      self.primary_host      = LinuxAdmin::NetworkInterface.new(NETWORK_INTERFACE).address
+      self.primary_host      = network_interfaces.first&.address
     end
 
     def ask_questions

--- a/lib/manageiq/appliance_console/database_replication_standby.rb
+++ b/lib/manageiq/appliance_console/database_replication_standby.rb
@@ -17,7 +17,7 @@ module ApplianceConsole
       self.database_user     = "root"
       self.database_password = nil
       self.primary_host      = nil
-      self.standby_host      = LinuxAdmin::NetworkInterface.new(NETWORK_INTERFACE).address
+      self.standby_host      = network_interfaces.first&.address
       self.resync_data       = false
     end
 

--- a/manageiq-appliance_console.gemspec
+++ b/manageiq-appliance_console.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "ed25519",                 ">= 1.2", "< 2.0"
   spec.add_runtime_dependency "highline",                "~> 2.1"
   spec.add_runtime_dependency "i18n",                    ">= 0.8"
-  spec.add_runtime_dependency "linux_admin",             "~> 3.0"
+  spec.add_runtime_dependency "linux_admin",             "~> 4.0"
   spec.add_runtime_dependency "manageiq-password",       "< 2"
   spec.add_runtime_dependency "net-scp",                 "~> 4.0"
   spec.add_runtime_dependency "net-ssh",                 "~> 7.2"

--- a/spec/database_replication_primary_spec.rb
+++ b/spec/database_replication_primary_spec.rb
@@ -1,7 +1,6 @@
 describe ManageIQ::ApplianceConsole::DatabaseReplicationPrimary do
   before do
-    stub_const("ManageIQ::ApplianceConsole::NETWORK_INTERFACE", "either_net")
-    expect(LinuxAdmin::NetworkInterface).to receive(:new).and_return(double(:address => "192.0.2.1"))
+    expect(LinuxAdmin::NetworkInterface).to receive(:list).and_return([double(:address => "192.0.2.1", :loopback? => false)])
     allow(subject).to receive(:say)
     allow(subject).to receive(:clear_screen)
     allow(subject).to receive(:agree)

--- a/spec/database_replication_standby_spec.rb
+++ b/spec/database_replication_standby_spec.rb
@@ -1,8 +1,7 @@
 describe ManageIQ::ApplianceConsole::DatabaseReplicationStandby do
   before do
     allow(ENV).to receive(:fetch).and_return("/test/postgres/directory")
-    stub_const("ManageIQ::ApplianceConsole::NETWORK_INTERFACE", "either_net")
-    expect(LinuxAdmin::NetworkInterface).to receive(:new).and_return(double(:address => "192.0.2.1"))
+    expect(LinuxAdmin::NetworkInterface).to receive(:list).and_return([double(:address => "192.0.2.1", :loopback? => false)])
     allow(subject).to receive(:say)
     allow(subject).to receive(:clear_screen)
     allow(subject).to receive(:agree)


### PR DESCRIPTION
When displaying the current network information iterate over all network interfaces not just eth0

Example output:
```
Welcome to the ManageIQ Virtual Appliance.

To modify the configuration, use a web browser to access the management page.

Hostname:                workstation
enp193s0f0np0 IPv4 Address: 10.2.4.10/24
enp193s0f0np0 IPv4 Gateway: 10.2.4.1
enp193s0f0np0 IPv6 Address: 
enp193s0f0np0 IPv6 Gateway: 
enp193s0f0np0 MAC Address: b4:96:91:b8:a2:96
lxcbr0 IPv4 Address:     10.0.3.1/24
lxcbr0 IPv4 Gateway:     10.2.4.1
lxcbr0 IPv6 Address:     fc11:4514:1919:810::1/64
lxcbr0 IPv6 Gateway:     
lxcbr0 MAC Address:      00:16:3e:00:00:00
crc IPv4 Address:        192.168.130.1/24
crc IPv4 Gateway:        10.2.4.1
crc IPv6 Address:        
crc IPv6 Gateway:        
crc MAC Address:         52:54:00:fd:be:d0
Primary DNS:             127.0.0.1
Secondary DNS:           
Search Order:            rb.nj.grare.com
Timezone:                America/New_York
ManageIQ Server:         not configured
ManageIQ Database:       not configured
Database/Region:         not configured
Messaging:               configured
Local Messaging Broker:  configured
ManageIQ Version: 
```

NOTE with longer interface names the spacing is broken

Related: https://github.com/ManageIQ/manageiq-appliance-build/pull/573
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
