### PR TITLE
CP4AIOPS-3113 Store saml remote user configuration separately from sssd lookup

### DIFF
--- a/lib/manageiq/appliance_console/saml_authentication.rb
+++ b/lib/manageiq/appliance_console/saml_authentication.rb
@@ -90,13 +90,15 @@ module ManageIQ
 
       def copy_apache_saml_configfiles
         debug_msg("Copying Apache SAML Config files ...")
-        copy_template(HTTPD_CONFIG_DIRECTORY, "manageiq-remote-user.conf")
+        copy_template(HTTPD_CONFIG_DIRECTORY, "manageiq-remote-user-saml.conf")
         copy_template(HTTPD_CONFIG_DIRECTORY, "manageiq-external-auth-saml.conf")
       end
 
       def remove_apache_saml_configfiles
         debug_msg("Removing Apache SAML Config files ...")
+        # legacy systems may have manageiq-remote-user.conf instead of manageiq-remote-user-saml.conf
         remove_file(HTTPD_CONFIG_DIRECTORY.join("manageiq-remote-user.conf"))
+        remove_file(HTTPD_CONFIG_DIRECTORY.join("manageiq-remote-user-saml.conf"))
         remove_file(HTTPD_CONFIG_DIRECTORY.join("manageiq-external-auth-saml.conf"))
       end
 

--- a/lib/manageiq/appliance_console/version.rb
+++ b/lib/manageiq/appliance_console/version.rb
@@ -1,5 +1,5 @@
 module ManageIQ
   module ApplianceConsole
-    VERSION = '9.1.1'.freeze
+    VERSION = '10.0.0'.freeze
   end
 end

--- a/spec/saml_authentication_spec.rb
+++ b/spec/saml_authentication_spec.rb
@@ -43,7 +43,7 @@ describe ManageIQ::ApplianceConsole::SamlAuthentication do
                                                   :params => ["https://#{client_host}", "https://#{client_host}/saml2"])
 
       allow(subject).to receive(:copy_template)
-      expect(subject).to receive(:copy_template).with(described_class::HTTPD_CONFIG_DIRECTORY, "manageiq-remote-user.conf").and_return(true)
+      expect(subject).to receive(:copy_template).with(described_class::HTTPD_CONFIG_DIRECTORY, "manageiq-remote-user-saml.conf").and_return(true)
       expect(subject).to receive(:copy_template).with(described_class::HTTPD_CONFIG_DIRECTORY, "manageiq-external-auth-saml.conf").and_return(true)
 
       expect(subject).to receive(:say).with("Setting Appliance Authentication Settings to SAML ...")
@@ -75,7 +75,7 @@ describe ManageIQ::ApplianceConsole::SamlAuthentication do
                                                   :params => ["https://#{client_host}", "https://#{client_host}/saml2"])
 
       allow(subject).to receive(:copy_template)
-      expect(subject).to receive(:copy_template).with(described_class::HTTPD_CONFIG_DIRECTORY, "manageiq-remote-user.conf").and_return(true)
+      expect(subject).to receive(:copy_template).with(described_class::HTTPD_CONFIG_DIRECTORY, "manageiq-remote-user-saml.conf").and_return(true)
       expect(subject).to receive(:copy_template).with(described_class::HTTPD_CONFIG_DIRECTORY, "manageiq-external-auth-saml.conf").and_return(true)
       expect(subject).to receive(:download_network_file).with(idp_metadata_url, described_class::IDP_METADATA_FILE).and_return(true)
 
@@ -113,7 +113,7 @@ describe ManageIQ::ApplianceConsole::SamlAuthentication do
       expect(FileUtils).to receive(:cp).with(downloaded_idp_metadata, described_class::IDP_METADATA_FILE).and_return(true)
 
       allow(subject).to receive(:copy_template)
-      expect(subject).to receive(:copy_template).with(described_class::HTTPD_CONFIG_DIRECTORY, "manageiq-remote-user.conf").and_return(true)
+      expect(subject).to receive(:copy_template).with(described_class::HTTPD_CONFIG_DIRECTORY, "manageiq-remote-user-saml.conf").and_return(true)
       expect(subject).to receive(:copy_template).with(described_class::HTTPD_CONFIG_DIRECTORY, "manageiq-external-auth-saml.conf").and_return(true)
 
       expect(subject).to receive(:say).with("Setting Appliance Authentication Settings to SAML ...")
@@ -138,6 +138,7 @@ describe ManageIQ::ApplianceConsole::SamlAuthentication do
       allow(subject).to receive(:remove_file)
       expect(subject).to receive(:remove_file).with(described_class::HTTPD_CONFIG_DIRECTORY.join("manageiq-external-auth-saml.conf")).and_return(true)
       expect(subject).to receive(:remove_file).with(described_class::HTTPD_CONFIG_DIRECTORY.join("manageiq-remote-user.conf")).and_return(true)
+      expect(subject).to receive(:remove_file).with(described_class::HTTPD_CONFIG_DIRECTORY.join("manageiq-remote-user-saml.conf")).and_return(true)
 
       expect(subject).to receive(:say).with(/Unconfiguring SAML Authentication .../)
       expect(subject).to receive(:say).with(/Setting Appliance Authentication Settings to Database .../)


### PR DESCRIPTION
Part of https://github.com/ManageIQ/manageiq/pull/23139

saml configuration (mod_auth_mellon) uses a different delimiter from sssd type configurations.

The templates have been changed to reflect this change. The appliance console is now respecting this change

