### PR TITLE
Fix warnings on newer ERB versions

### DIFF
--- a/lib/manageiq/appliance_console/external_httpd_authentication/external_httpd_configuration.rb
+++ b/lib/manageiq/appliance_console/external_httpd_authentication/external_httpd_configuration.rb
@@ -201,7 +201,7 @@ module ApplianceConsole
         src_path  = path_join(src_dir, file)
         dest_path = path_join(dest_dir, file.gsub(".erb", ""))
         if src_path.to_s.include?(".erb")
-          File.write(dest_path, ERB.new(File.read(src_path), nil, '-').result(binding))
+          File.write(dest_path, ERB.new(File.read(src_path), trim_mode: '-').result(binding))
         else
           FileUtils.cp src_path, dest_path
         end


### PR DESCRIPTION
Fixes the follow warnings seen in the logs:

```
warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
```

@jrafanie Please review.