### PR TITLE
readline does not work with ruby 3.3

### DIFF
--- a/lib/manageiq/appliance_console/database_admin.rb
+++ b/lib/manageiq/appliance_console/database_admin.rb
@@ -118,15 +118,11 @@ module ManageIQ
       end
 
       def should_exclude_tables?
-        ask_yn?("Would you like to exclude tables in the dump") do |q|
-          q.readline = true
-        end
+        ask_yn?("Would you like to exclude tables in the dump")
       end
 
       def should_split_output?
-        ask_yn?("Would you like to split the #{action} output into multiple parts") do |q|
-          q.readline = true
-        end
+        ask_yn?("Would you like to split the #{action} output into multiple parts")
       end
 
       def filename_prompt_args

--- a/lib/manageiq/appliance_console/prompts.rb
+++ b/lib/manageiq/appliance_console/prompts.rb
@@ -212,7 +212,6 @@ module ApplianceConsole
 
     def just_ask(prompt, default = nil, validate = nil, error_text = nil, klass = nil)
       ask("Enter the #{prompt}: ", klass) do |q|
-        q.readline = true
         q.default = default.to_s if default
         q.validate = validate if validate
         q.responses[:not_valid] = error_text ? "Please provide #{error_text}" : "Please provide in the specified format"


### PR DESCRIPTION
readline is making the prompt disappear when enabled, disable for now until we can get to highline 3.0+ where they switch to reline.

Unfortunately this breaks the ability for users to use the arrow keys to fix typos in prompts, but it does make the prompts visible until we have the time to get to highline 3.0+.