### PR TITLE
Fix spec failures if sssd.conf file exists

### DIFF
--- a/spec/external_httpd_authentication_spec.rb
+++ b/spec/external_httpd_authentication_spec.rb
@@ -185,6 +185,11 @@ describe ManageIQ::ApplianceConsole::ExternalHttpdAuthentication do
   end
 
   context "#config_status" do
+    before do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with("/etc/sssd/sssd.conf").and_return(false)
+    end
+
     it "Returns not configured" do
       expect(described_class.config_status).to eq("not configured")
     end


### PR DESCRIPTION
If `/etc/sssd/sssd.conf` file exists then spec tests will fail
```
  1) ManageIQ::ApplianceConsole::ExternalHttpdAuthentication#config_status Returns not configured
     Failure/Error: File.read(path)

     Errno::EACCES:
       Permission denied @ rb_sysopen - /etc/sssd/sssd.conf
     # ./lib/manageiq/appliance_console/external_httpd_authentication/external_httpd_configuration.rb:220:in `read'
     # ./lib/manageiq/appliance_console/external_httpd_authentication/external_httpd_configuration.rb:220:in `config_file_read'
     # ./lib/manageiq/appliance_console/external_httpd_authentication/external_httpd_configuration.rb:233:in `fetch_sssd_domain'
     # ./lib/manageiq/appliance_console/external_httpd_authentication/external_httpd_configuration.rb:209:in `config_status'
     # ./spec/external_httpd_authentication_spec.rb:194:in `block (3 levels) in <top (required)>'

rspec ./spec/external_httpd_authentication_spec.rb:193 # ManageIQ::ApplianceConsole::ExternalHttpdAuthentication#config_status Returns not configured

```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
