### PR TITLE
Support rails 7.2 - Fix deprecation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,8 +14,8 @@ jobs:
         - '3.1'
         - '3.3'
         rails-version:
-        - '7.0'
         - '7.1'
+        - '7.2'
     services:
       postgres:
         image: manageiq/postgresql:13

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ jobs:
         ruby-version:
         - '3.1'
         - '3.3'
+        - '3.4'
         rails-version:
         - '7.1'
         - '7.2'

--- a/Gemfile
+++ b/Gemfile
@@ -5,10 +5,10 @@ gemspec
 
 minimum_version =
   case ENV['TEST_RAILS_VERSION']
-  when "7.0"
-    "~>7.0.8"
+  when "7.2"
+    "~>7.2.2"
   else
-    "~>6.1.4"
+    "~>7.1.5"
   end
 
 gem "activerecord", minimum_version

--- a/lib/manageiq/appliance_console/database_configuration.rb
+++ b/lib/manageiq/appliance_console/database_configuration.rb
@@ -205,7 +205,7 @@ FRIENDLY
     def validate!
       pool = ModelWithNoBackingTable.establish_connection(settings_hash.delete_if { |_n, v| v.blank? })
       begin
-        pool.connection
+        pool.with_connection { |conn| conn.connect! && conn.connected? }
       ensure
         ModelWithNoBackingTable.remove_connection
       end

--- a/manageiq-appliance_console.gemspec
+++ b/manageiq-appliance_console.gemspec
@@ -27,6 +27,13 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "bcrypt_pbkdf",            ">= 1.0", "< 2.0"
   spec.add_runtime_dependency "ed25519",                 ">= 1.2", "< 2.0"
   spec.add_runtime_dependency "highline",                "~> 2.1"
+
+  # These two dependencies can be removed for ruby 3.4 support once we upgrade highline:
+  #   abbrev is not in ruby 3.4 standard library and no longer a dependency in highline 3.0.1
+  #   reline is not in ruby 3.4 standard library and added as a runtime dependency in highline 3.1.0
+  spec.add_runtime_dependency "abbrev"
+  spec.add_runtime_dependency "reline"
+
   spec.add_runtime_dependency "i18n",                    ">= 0.8"
   spec.add_runtime_dependency "linux_admin",             "~> 4.0"
   spec.add_runtime_dependency "manageiq-password",       "< 2"


### PR DESCRIPTION
* Add 3.4 to test matrix
  These two dependencies can be removed for ruby 3.4 support once we upgrade highline:
  * abbrev is not in ruby 3.4 standard library and no longer a dependency in highline 3.0.1
  * reline is not in ruby 3.4 standard library and added as a runtime dependency in highline 3.1.0
* Test with rails 7.2 and 7.1
* Fix deprecated AR::ConnectionAdapters::ConnectionPool#connection

    Very similar change to https://github.com/ManageIQ/manageiq/pull/23511

    Before:
    ```
    % TEST_RAILS_VERSION=7.2 be irb
    irb(main):001> require_relative 'lib/manageiq/appliance_console'; ManageIQ::ApplianceConsole::DatabaseConfiguration.new(:username => "root", :host => "localhost", :database => "vmdb_development").validate!; nil
    DEPRECATION WARNING: ActiveRecord::ConnectionAdapters::ConnectionPool#connection is deprecated
    and will be removed in Rails 8.0. Use #lease_connection instead.
     (called from validate! at /Users/joerafaniello/Code/manageiq-appliance_console/lib/manageiq/appliance_console/database_configuration.rb:208)
    => nil
    ```

    After:
    ```
    % TEST_RAILS_VERSION=7.2 be irb
    irb(main):001> require_relative 'lib/manageiq/appliance_console'; ManageIQ::ApplianceConsole::DatabaseConfiguration.new(:username => "root", :host => "localhost", :database => "vmdb_development").validate!; nil
    => nil
    ```

