### PR TITLE
Add krbPrincipalName to sssd.conf user attributes

### DIFF
--- a/lib/manageiq/appliance_console/external_httpd_authentication/external_httpd_configuration.rb
+++ b/lib/manageiq/appliance_console/external_httpd_authentication/external_httpd_configuration.rb
@@ -31,11 +31,12 @@ module ApplianceConsole
       TIMESTAMP_FORMAT      = "%Y%m%d_%H%M%S".freeze
 
       LDAP_ATTRS            = {
-        "mail"        => "REMOTE_USER_EMAIL",
-        "givenname"   => "REMOTE_USER_FIRSTNAME",
-        "sn"          => "REMOTE_USER_LASTNAME",
-        "displayname" => "REMOTE_USER_FULLNAME",
-        "domainname"  => "REMOTE_USER_DOMAIN"
+        "mail"             => "REMOTE_USER_EMAIL",
+        "givenname"        => "REMOTE_USER_FIRSTNAME",
+        "sn"               => "REMOTE_USER_LASTNAME",
+        "displayname"      => "REMOTE_USER_FULLNAME",
+        "domainname"       => "REMOTE_USER_DOMAIN",
+        "krbPrincipalName" => "REMOTE_USER_PRINCIPAL"
       }.freeze
 
       def template_directory


### PR DESCRIPTION
The principal name provides a consistent username for creating user records since sssd supports logins with email or the username from the authentication system (freeipa).  Using this consistent principal name prevents creating duplicate users created from both the free ipa username and from the configured email address.

Related:
https://github.com/ManageIQ/manageiq/pull/23723
https://github.com/ManageIQ/manageiq-appliance/pull/401

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
