### PR TITLE
Tell clients the preferred hostname for connections

### DIFF
--- a/lib/manageiq/appliance_console/message_configuration_server.rb
+++ b/lib/manageiq/appliance_console/message_configuration_server.rb
@@ -253,6 +253,7 @@ module ManageIQ
         content = <<~SERVER_PROPERTIES
 
           listeners=SASL_SSL://:#{message_server_port}
+          advertised.listeners=SASL_SSL://#{message_server_host}:#{message_server_port}
 
           ssl.endpoint.identification.algorithm=#{ident_algorithm}
           ssl.keystore.location=#{keystore_path}

--- a/spec/message_configuration_server_spec.rb
+++ b/spec/message_configuration_server_spec.rb
@@ -232,6 +232,7 @@ describe ManageIQ::ApplianceConsole::MessageServerConfiguration do
       <<~SERVER_PROPERTIES
 
         listeners=SASL_SSL://:9093
+        advertised.listeners=SASL_SSL://#{subject.message_server_host}:9093
 
         ssl.endpoint.identification.algorithm=#{ident_algorithm}
         ssl.keystore.location=#{subject.keystore_path}


### PR DESCRIPTION
Our SSL certificates are only valid for one hostname, ensure that connections are using that hostname otherwise SSL connections will fail because it could pick an IP address or some other hostname that is not valid for the cert.
