### PR TITLE
[WIP] Add support for multiple messaging hosts

### DIFF
--- a/lib/manageiq/appliance_console/cli.rb
+++ b/lib/manageiq/appliance_console/cli.rb
@@ -229,7 +229,8 @@ module ApplianceConsole
         opt :message_server_password,       "Message Server password",                                        :type => :string
         opt :message_server_port,           "Message Server Port",                                            :type => :integer
         opt :message_server_use_ipaddr,     "Deprecated: Message Server Use Address",                         :type => :boolean, :default => false
-        opt :message_server_host,           "Message Server Hostname or IP Address",                          :type => :string
+        opt :message_server_host,           "Message Server Hostname or IP Address (single host)",            :type => :string
+        opt :message_server_hosts,          "Message Server Hostnames (comma-separated for HA)",              :type => :string
         opt :message_truststore_path_src,   "Message Server Truststore Path",                                 :type => :string
         opt :message_ca_cert_path_src,      "Message Server CA Cert Path",                                    :type => :string
         opt :message_persistent_disk,       "Message Persistent Disk Path",                                   :type => :string
@@ -243,6 +244,7 @@ module ApplianceConsole
       end
       Optimist.die :region, "needed when setting up a local database" if region_number_required? && options[:region].nil?
       Optimist.die "Supply only one of --message-server-config, --message-server-unconfig, --message-client-config or --message-client-unconfig" if multiple_message_subcommands?
+      Optimist.die "Supply only one of --message-server-host or --message-server-hosts" if options[:message_server_host] && options[:message_server_hosts]
       warn("--message_server_use_ipaddr is deprecated and will be ignored") if options[:message_server_use_ipaddr]
       self
     end

--- a/lib/manageiq/appliance_console/message_configuration.rb
+++ b/lib/manageiq/appliance_console/message_configuration.rb
@@ -10,7 +10,7 @@ module ManageIQ
       include ManageIQ::ApplianceConsole::Prompts
 
       attr_reader :message_keystore_username, :message_keystore_password,
-                  :message_server_host, :message_server_port,
+                  :message_server_hosts, :message_server_port,
                   :miq_config_dir_path, :config_dir_path, :sample_config_dir_path,
                   :client_properties_path,
                   :keystore_dir_path, :truststore_path, :keystore_path,
@@ -37,6 +37,15 @@ module ManageIQ
         @message_keystore_username  = options[:message_keystore_username] || "admin"
         @message_keystore_password  = options[:message_keystore_password]
 
+        # Handle both single and multiple host parameters - store everything in @message_server_hosts array
+        @message_server_hosts = if options[:message_server_hosts]
+                                  parse_hosts(options[:message_server_hosts])
+                                elsif options[:message_server_host]
+                                  [options[:message_server_host]]
+                                else
+                                  []
+                                end
+
         @miq_config_dir_path        = Pathname.new(MIQ_CONFIG_DIR)
         @config_dir_path            = Pathname.new(CONFIG_DIR)
         @sample_config_dir_path     = Pathname.new(SAMPLE_CONFIG_DIR)
@@ -49,6 +58,23 @@ module ManageIQ
         @messaging_yaml_sample_path = miq_config_dir_path.join("messaging.kafka.yml")
         @messaging_yaml_path        = miq_config_dir_path.join("messaging.yml")
         @ca_cert_path               = keystore_dir_path.join("ca-cert")
+      end
+
+      # Parse comma-separated host string into array
+      def parse_hosts(hosts_input)
+        return [] if hosts_input.blank?
+
+        hosts_input.split(',').map(&:strip).reject(&:empty?)
+      end
+
+      # Get first host (for backward compatibility and file fetching)
+      def primary_message_server_host
+        message_server_hosts.first
+      end
+
+      # Check if multiple hosts configured
+      def multiple_hosts?
+        message_server_hosts.length > 1
       end
 
       def already_configured?
@@ -69,8 +95,17 @@ module ManageIQ
         show_parameters
         return false unless agree("\nProceed? (Y/N): ")
 
-        return false unless host_resolvable?(message_server_host) && host_reachable?(message_server_host, "Message Server Host:")
+        return false unless all_hosts_valid?
 
+        true
+      end
+
+      # Validate all configured hosts
+      def all_hosts_valid?
+        message_server_hosts.each do |host|
+          return false unless host_resolvable?(host)
+          return false unless host_reachable?(host, "Message Server Host")
+        end
         true
       end
 
@@ -79,7 +114,8 @@ module ManageIQ
 
         return if file_found?(client_properties_path)
 
-        algorithm = message_server_host.ipaddress? ? "" : "HTTPS"
+        # Determine algorithm based on first host (all should be same type)
+        algorithm = primary_message_server_host.ipaddress? ? "" : "HTTPS"
         protocol = secure? ? "SASL_SSL" : "PLAINTEXT"
         content = secure? ? secure_client_properties_content(algorithm, protocol) : unsecure_client_properties_content(algorithm, protocol)
 
@@ -96,7 +132,11 @@ module ManageIQ
       end
 
       def unsecure_client_properties_content(algorithm, protocol)
+        # Format hosts as host1:port,host2:port,host3:port for bootstrap.servers
+        bootstrap_servers = message_server_hosts.map { |host| "#{host}:#{message_server_port}" }.join(',')
+
         <<~CLIENT_PROPERTIES
+          bootstrap.servers=#{bootstrap_servers}
           ssl.endpoint.identification.algorithm=#{algorithm}
 
           sasl.mechanism=PLAIN
@@ -120,7 +160,13 @@ module ManageIQ
             YAML.load(data) # rubocop:disable Security/YAMLLoad
           end
 
-        messaging_yaml["production"]["host"]      = message_server_host
+        # Use "host" for single host, "hosts" array for multiple hosts
+        if multiple_hosts?
+          messaging_yaml["production"].delete("host")
+          messaging_yaml["production"]["hosts"]   = message_server_hosts
+        else
+          messaging_yaml["production"]["host"]    = message_server_hosts.first
+        end
         messaging_yaml["production"]["port"]      = message_server_port
         messaging_yaml["production"]["username"]  = message_keystore_username
         messaging_yaml["production"]["password"]  = ManageIQ::Password.try_encrypt(message_keystore_password)

--- a/lib/manageiq/appliance_console/message_configuration_client.rb
+++ b/lib/manageiq/appliance_console/message_configuration_client.rb
@@ -13,8 +13,9 @@ module ManageIQ
       def initialize(options = {})
         super(options)
 
-        @message_server_host         = options[:message_server_host]
-        @message_server_username     = options[:message_server_usernamed] || "root"
+        # Parent class handles message_server_host(s) initialization
+
+        @message_server_username     = options[:message_server_username] || "root"
         @message_server_password     = options[:message_server_password]
 
         @message_truststore_path_src = options[:message_truststore_path_src] || truststore_path
@@ -46,7 +47,19 @@ module ManageIQ
       def ask_for_parameters
         say("\nMessage Client Parameters:\n\n")
 
-        @message_server_host         = ask_for_messaging_hostname("Message Server Hostname")
+        # Ask if user wants HA configuration
+        use_ha = agree("Configure High Availability with multiple hosts? (Y/N): ")
+
+        if use_ha
+          # Prompt for comma-separated hosts
+          hosts_input = ask_for_string("Message Server Hostnames (comma-separated)")
+          @message_server_hosts = parse_hosts(hosts_input)
+        else
+          # Prompt for single host
+          single_host = ask_for_messaging_hostname("Message Server Hostname")
+          @message_server_hosts = [single_host]
+        end
+
         @message_server_port         = ask_for_integer("Message Server Port number", (1..65_535), 9_093).to_i
         @message_server_username     = ask_for_string("Message Server Username", message_server_username)
         @message_server_password     = ask_for_password("Message Server Password")
@@ -59,9 +72,17 @@ module ManageIQ
       def show_parameters
         say("\nMessage Client Configuration:\n")
         say("Message Client Details:\n")
-        say("  Message Server Hostname:   #{message_server_host}\n")
+
+        if multiple_hosts?
+          say("  Message Server Hostnames:  #{message_server_hosts.join(', ')}\n")
+          say("  (High Availability Mode with #{message_server_hosts.length} hosts)\n")
+        else
+          say("  Message Server Hostname:   #{message_server_hosts.first}\n")
+        end
+
+        say("  Message Server Port:       #{message_server_port}\n")
         say("  Message Server Username:   #{message_server_username}\n")
-        say("  Message Keystore Username: #{message_keystore_username}\n")
+        say("  Message Keystore Username: #{message_keystore_username}\n") if secure?
       end
 
       def fetch_truststore_from_server
@@ -87,13 +108,16 @@ module ManageIQ
 
         FileUtils.mkdir_p(dst_file.dirname) unless dst_file.dirname.directory?
 
-        Net::SCP.start(message_server_host, message_server_username, :password => message_server_password) do |scp|
+        # Use primary host for file fetching
+        host = primary_message_server_host
+
+        Net::SCP.start(host, message_server_username, :password => message_server_password) do |scp|
           scp.download!(src_file, dst_file)
         end
 
         File.exist?(dst_file)
       rescue => e
-        say("Failed to fetch #{src_file} from server: #{e.message}")
+        say("Failed to fetch #{src_file} from server #{host}: #{e.message}")
         false
       end
     end

--- a/lib/manageiq/appliance_console/message_configuration_server.rb
+++ b/lib/manageiq/appliance_console/message_configuration_server.rb
@@ -15,9 +15,11 @@ module ManageIQ
       PERSISTENT_NAME = "kafka_messages".freeze
 
       def initialize(options = {})
+        # Set message_server_host option before calling super if not provided
+        options[:message_server_host] ||= my_hostname
+
         super(options)
 
-        @message_server_host           = options[:message_server_host] || my_hostname
         @message_persistent_disk       = LinuxAdmin::Disk.new(:path => options[:message_persistent_disk]) unless options[:message_persistent_disk].nil?
 
         @jaas_config_path              = config_dir_path.join("kafka_server_jaas.conf")
@@ -68,7 +70,8 @@ module ManageIQ
       def ask_for_parameters
         say("\nMessage Server Parameters:\n\n")
 
-        @message_server_host       = ask_for_messaging_hostname("Message Server Hostname", message_server_host)
+        hostname = ask_for_messaging_hostname("Message Server Hostname", message_server_host)
+        @message_server_hosts = [hostname]
 
         @message_keystore_username = ask_for_string("Message Keystore Username", message_keystore_username)
         @message_keystore_password = ask_for_messaging_password("Message Keystore Password")
@@ -105,6 +108,10 @@ module ManageIQ
       def self.configured?
         LinuxAdmin::Service.new("kafka").running? ||
           LinuxAdmin::Service.new("zookeeper").running?
+      end
+
+      def message_server_host
+        message_server_hosts.first
       end
 
       private

--- a/spec/message_configuration_client_spec.rb
+++ b/spec/message_configuration_client_spec.rb
@@ -46,8 +46,9 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
     end
 
     it "should prompt for message_keystore_username and message_keystore_password" do
+      expect(subject).to receive(:agree).with("Configure High Availability with multiple hosts? (Y/N): ").and_return(false)
       expect(subject).to receive(:ask_for_messaging_hostname).with("Message Server Hostname").and_return("my-host-name.example.com")
-      expect(subject).to receive(:ask_for_integer).with("Message Server Port number", (1..65_535), 9_093).and_return("9093")
+      expect(subject).to receive(:ask_for_integer).with("Message Server Port number", 1..65_535, 9_093).and_return("9093")
       expect(subject).to receive(:ask_for_string).with("Message Keystore Username", message_keystore_username).and_return("admin")
       expect(subject).to receive(:ask_for_messaging_password).with("Message Keystore Password").and_return("top_secret")
       expect(subject).to receive(:ask_for_string).with("Message Server Truststore Path", subject.truststore_path)
@@ -62,8 +63,9 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
     end
 
     it "should display Server Hostname and Key Username" do
+      allow(subject).to receive(:agree).with("Configure High Availability with multiple hosts? (Y/N): ").and_return(false)
       allow(subject).to receive(:ask_for_messaging_hostname).with("Message Server Hostname").and_return("my-kafka-server.example.com")
-      allow(subject).to receive(:ask_for_integer).with("Message Server Port number", (1..65_535), 9_093).and_return("9093")
+      allow(subject).to receive(:ask_for_integer).with("Message Server Port number", 1..65_535, 9_093).and_return("9093")
       allow(subject).to receive(:ask_for_string).with("Message Keystore Username", message_keystore_username).and_return("admin")
       allow(subject).to receive(:ask_for_messaging_password).with("Message Keystore Password").and_return("top_secret")
       allow(subject).to receive(:ask_for_string).with("Message Server Truststore Path", subject.truststore_path)
@@ -76,8 +78,57 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
       expect(subject).to receive(:say).with("\nMessage Client Configuration:\n")
       expect(subject).to receive(:say).with("Message Client Details:\n")
       expect(subject).to receive(:say).with("  Message Server Hostname:   my-kafka-server.example.com\n")
+      expect(subject).to receive(:say).with("  Message Server Port:       9093\n")
       expect(subject).to receive(:say).with("  Message Server Username:   root\n")
       expect(subject).to receive(:say).with("  Message Keystore Username: admin\n")
+
+      expect(subject.send(:ask_questions)).to be_truthy
+    end
+
+    it "should prompt for multiple hosts when HA mode is selected" do
+      expect(subject).to receive(:agree).with("Configure High Availability with multiple hosts? (Y/N): ").and_return(true)
+      expect(subject).to receive(:ask_for_string).with("Message Server Hostnames (comma-separated)").and_return("host1.example.com,host2.example.com,host3.example.com")
+      expect(subject).to receive(:ask_for_integer).with("Message Server Port number", 1..65_535, 9_093).and_return("9093")
+      expect(subject).to receive(:ask_for_string).with("Message Keystore Username", message_keystore_username).and_return("admin")
+      expect(subject).to receive(:ask_for_messaging_password).with("Message Keystore Password").and_return("top_secret")
+      expect(subject).to receive(:ask_for_string).with("Message Server Truststore Path", subject.truststore_path)
+      expect(subject).to receive(:ask_for_string).with("Message Server CA Cert Path", subject.ca_cert_path)
+
+      expect(subject).to receive(:ask_for_string).with("Message Server Username", message_server_username).and_return("root")
+      expect(subject).to receive(:ask_for_password).with("Message Server Password").and_return("top_secret")
+
+      expect(subject).to receive(:say).at_least(5).times
+      expect(subject).to receive(:agree).with("\nProceed? (Y/N): ").and_return(true)
+      allow(subject).to receive(:host_resolvable?).and_return(true)
+      allow(subject).to receive(:host_reachable?).and_return(true)
+
+      expect(subject.send(:ask_questions)).to be_truthy
+    end
+
+    it "should display multiple hostnames when HA mode is configured" do
+      allow(subject).to receive(:agree).with("Configure High Availability with multiple hosts? (Y/N): ").and_return(true)
+      allow(subject).to receive(:ask_for_string).with("Message Server Hostnames (comma-separated)").and_return("host1.example.com, host2.example.com, host3.example.com")
+      allow(subject).to receive(:ask_for_integer).with("Message Server Port number", 1..65_535, 9_093).and_return("9093")
+      allow(subject).to receive(:ask_for_string).with("Message Keystore Username", message_keystore_username).and_return("admin")
+      allow(subject).to receive(:ask_for_messaging_password).with("Message Keystore Password").and_return("top_secret")
+      allow(subject).to receive(:ask_for_string).with("Message Server Truststore Path", subject.truststore_path)
+      allow(subject).to receive(:ask_for_string).with("Message Server CA Cert Path", subject.ca_cert_path)
+
+      allow(subject).to receive(:ask_for_string).with("Message Server Username", message_server_username).and_return("root")
+      allow(subject).to receive(:ask_for_password).with("Message Server Password").and_return("top_secret")
+
+      expect(subject).to receive(:say).with("\nMessage Client Parameters:\n\n")
+      expect(subject).to receive(:say).with("\nMessage Client Configuration:\n")
+      expect(subject).to receive(:say).with("Message Client Details:\n")
+      expect(subject).to receive(:say).with("  Message Server Hostnames:  host1.example.com, host2.example.com, host3.example.com\n")
+      expect(subject).to receive(:say).with("  (High Availability Mode with 3 hosts)\n")
+      expect(subject).to receive(:say).with("  Message Server Port:       9093\n")
+      expect(subject).to receive(:say).with("  Message Server Username:   root\n")
+      expect(subject).to receive(:say).with("  Message Keystore Username: admin\n")
+
+      allow(subject).to receive(:agree).with("\nProceed? (Y/N): ").and_return(true)
+      allow(subject).to receive(:host_resolvable?).and_return(true)
+      allow(subject).to receive(:host_reachable?).and_return(true)
 
       expect(subject.send(:ask_questions)).to be_truthy
     end
@@ -95,6 +146,7 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
 
     let(:secure_content) do
       <<~CLIENT_PROPERTIES
+        bootstrap.servers=#{message_server_host}:#{message_server_port}
         ssl.endpoint.identification.algorithm=#{ident_algorithm}
 
         sasl.mechanism=PLAIN
@@ -109,6 +161,7 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
 
     let(:unsecure_content) do
       <<~CLIENT_PROPERTIES
+        bootstrap.servers=#{message_server_host}:#{message_server_port}
         ssl.endpoint.identification.algorithm=#{ident_algorithm}
 
         sasl.mechanism=PLAIN
@@ -324,6 +377,55 @@ describe ManageIQ::ApplianceConsole::MessageClientConfiguration do
     context "when using unsecure port 9092" do
       let(:content) { unsecure_messagine_yml_content }
       let(:message_server_port) { 9_092 }
+      include_examples "messaging yaml file"
+    end
+
+    context "when using multiple hosts with secure port 9093" do
+      let(:message_server_host) { "host1.example.com,host2.example.com,host3.example.com" }
+      let(:message_server_port) { 9_093 }
+      let(:content) do
+        <<~SECURE_MESSAGING_YML_MULTI
+          ---
+          base:
+            host: localhost
+            port: 9092
+            protocol: Kafka
+            encoding: json
+            username: admin
+            password: smartvm
+          development:
+            host: localhost
+            port: 9092
+            protocol: Kafka
+            encoding: json
+            username: admin
+            password: smartvm
+          production:
+            port: 9093
+            protocol: Kafka
+            encoding: json
+            username: admin
+            password: #{ManageIQ::Password.try_encrypt("super_secret")}
+            hosts:
+            - host1.example.com
+            - host2.example.com
+            - host3.example.com
+            ssl: true
+            ca_file: "#{@tmp_base_dir}/config/keystore/ca-cert"
+          test:
+            host: localhost
+            port: 9092
+            protocol: Kafka
+            encoding: json
+            username: admin
+            password: smartvm
+        SECURE_MESSAGING_YML_MULTI
+      end
+
+      before do
+        subject.instance_variable_set(:@message_server_hosts, ["host1.example.com", "host2.example.com", "host3.example.com"])
+      end
+
       include_examples "messaging yaml file"
     end
   end


### PR DESCRIPTION
If you want to run kafka in HA mode you can specify multiple bootstrap servers via the --messaging-server-hosts parameter in the CLI or prompt.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
